### PR TITLE
Find distributions installation instead of src.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ before_install:
   - cd distributions
   - pip install -r requirements.txt --download-cache $HOME/.pip-cache
   - git pull
-  - make install
+  - DISTRIBUTIONS_USE_PROTOBUF=1 make install
   - cd $CLONE
 env:
-  - DISTRIBUTIONS_PATH="$HOME/distributions" CXX_FLAGS="-march=native"
+  - CXX_FLAGS="-march=native"
 install:
   - make install
   - pip freeze

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,30 +20,23 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS} -DNDEBUG=1")
 
 include_directories("${CMAKE_SOURCE_DIR}/include")
 
-# distributions
-include(ExternalProject)
-if(DEFINED ENV{DISTRIBUTIONS_PATH})
-  ExternalProject_Add(distributions
-    PREFIX distributions
-    DOWNLOAD_COMMAND ""
-    SOURCE_DIR $ENV{DISTRIBUTIONS_PATH}
-    BINARY_DIR $ENV{DISTRIBUTIONS_PATH}/build
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-  )
+# germ of a future FindDistributions.cmake
+find_path(DISTRIBUTIONS_INCLUDE_DIR distributions/random.hpp)
+if(NOT DISTRIBUTIONS_INCLUDE_DIR)
+  message(FATAL_ERROR
+    "distributions include dir not found, try setting CMAKE_PREFIX_PATH")
 else()
-  ExternalProject_Add(distributions
-    PREFIX distributions
-    GIT_REPOSITORY https://github.com/forcedotcom/distributions.git
-    INSTALL_COMMAND ""
-  )
+  message(STATUS
+    "using distributions include dir ${DISTRIBUTIONS_INCLUDE_DIR}")
 endif()
-ExternalProject_Get_Property(distributions SOURCE_DIR)
-ExternalProject_Get_Property(distributions BINARY_DIR)
-include_directories("${SOURCE_DIR}/include")
-link_directories("${BINARY_DIR}/src")
-set(DISTRIBUTIONS_PATH ${SOURCE_DIR})
-
+find_library(DISTRIBUTIONS_LIBRARIES distributions_shared)
+if(NOT DISTRIBUTIONS_LIBRARIES)
+  message(FATAL_ERROR
+    "distributions libraries not found, try setting CMAKE_PREFIX_PATH")
+endif()
 
 add_subdirectory(src)
+
+set(CPACK_GENERATOR "TGZ")
+set(CPACK_PACKAGE_FILE_NAME "loom")
+include(CPack)

--- a/setup.py
+++ b/setup.py
@@ -29,15 +29,15 @@ import os
 import re
 from distutils.core import setup, Extension
 from Cython.Build import cythonize
-import distributions
 
-libraries = ['protobuf']
 
-include_dirs = [
-    'include',
-    os.path.join(distributions.ROOT, 'include'),
-]
-
+library_dirs = []
+libraries = ['protobuf', 'distributions_shared']
+include_dirs = ['include']
+ve = os.environ.get('VIRTUAL_ENV')
+if ve:
+    include_dirs.append(os.path.join(ve, 'include'))
+    library_dirs.append(os.path.join(ve, 'lib'))
 extra_compile_args = [
     '-DDIST_DEBUG_LEVEL=3',
     '-DDIST_THROW_ON_ERROR=1',
@@ -60,19 +60,14 @@ def make_extension(name, sources=[]):
         sources=sources,
         language='c++',
         include_dirs=include_dirs,
+        library_dirs=library_dirs,
         libraries=libraries,
         extra_compile_args=extra_compile_args,
     )
 
 
 ext_modules = [
-    make_extension(
-        'cFormat',
-        sources=[
-            os.path.join(distributions.ROOT, 'src/io/schema.pb.cc'),
-            'src/schema.pb.cc',
-        ],
-    ),
+    make_extension('cFormat', sources=['src/schema.pb.cc']),
 ]
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,11 @@
 include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${DISTRIBUTIONS_INCLUDE_DIR})
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_LIST_DIR}/schema.pb.cc
   COMMAND protoc ${CMAKE_CURRENT_LIST_DIR}/schema.proto
     --proto_path=${CMAKE_CURRENT_LIST_DIR}
-    --proto_path=${DISTRIBUTIONS_PATH}
+    --proto_path=${DISTRIBUTIONS_INCLUDE_DIR}
     --cpp_out=${CMAKE_CURRENT_LIST_DIR}
     --python_out=${CMAKE_CURRENT_LIST_DIR}/../loom
   DEPENDS ${CMAKE_CURRENT_LIST_DIR}/schema.proto
@@ -27,12 +28,12 @@ add_library(loom
   kind_proposer.cc
   kind_pipeline.cc
   schema.pb.cc
-  ${DISTRIBUTIONS_PATH}/src/io/schema.pb.cc
+  ${DISTRIBUTIONS_INCLUDE_DIR}/distributions/io/schema.pb.cc
 )
 
 set(LOOM_LIBRARIES
   loom
-  distributions_shared
+  ${DISTRIBUTIONS_LIBRARIES}
   protobuf
   pthread
   tcmalloc
@@ -56,3 +57,7 @@ target_link_libraries(generate ${LOOM_LIBRARIES})
 
 add_executable(query query.cc)
 target_link_libraries(query ${LOOM_LIBRARIES})
+
+install(TARGETS shuffle infer posterior_enum generate query
+  RUNTIME DESTINATION bin
+)


### PR DESCRIPTION
Using distributions' new installation ability, find it there instead of assuming we have the src tree available. Also add a target to package up loom binaries.
