### PR TITLE
Implement sparse ProductValue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,13 @@ clean: FORCE
 data: dev FORCE
 	python -m loom.datasets generate
 
-test: dev data
+test: dev
 	@pyflakes loom/schema_pb2.py \
 	  || (echo '...patching schema_pb2.py' \
 	    ; sed -i '/descriptor_pb2/d' loom/schema_pb2.py)  # HACK
 	pyflakes setup.py loom examples
 	pep8 --repeat --ignore=E265 --exclude=*_pb2.py setup.py loom examples
+	python -m loom.datasets generate-test
 	$(nose_env) nosetests -v loom examples/taxi
 	@echo '----------------'
 	@echo 'PASSED ALL TESTS'

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,10 @@ test: dev
 	@echo '----------------'
 	@echo 'PASSED ALL TESTS'
 
+big-test:
+	LOOM_TEST_COST=1000 $(MAKE) test
+
+bigger-test:
+	LOOM_TEST_COST=10000 $(MAKE) test
+
 FORCE:

--- a/loom/benchmark.py
+++ b/loom/benchmark.py
@@ -68,21 +68,25 @@ parsable.command(loom.runner.profilers)
 @parsable.command
 def generate(
         feature_type='mixed',
-        rows=10000,
-        cols=100,
+        row_count=10000,
+        feature_count=100,
         density=0.5,
         debug=False,
         profile='time'):
     '''
     Generate a synthetic dataset.
     '''
-    name = '{}-{}-{}-{}'.format(feature_type, rows, cols, density)
+    name = '{}-{}-{}-{}'.format(
+        feature_type,
+        row_count,
+        feature_count,
+        density)
     dataset = loom.store.get_dataset(name)
     results = loom.store.get_results('generate', name)
 
     loom.generate.generate(
-        row_count=rows,
-        feature_count=cols,
+        row_count=row_count,
+        feature_count=feature_count,
         feature_type=feature_type,
         density=density,
         init_out=results['init'],

--- a/loom/cFormat.pyx
+++ b/loom/cFormat.pyx
@@ -104,6 +104,7 @@ cdef class Row:
 
     def Clear(self):
         self.ptr.Clear()
+        self.ptr.data().observed().set_sparsity(SPARSITY_DENSE)
 
     def ByteSize(self):
         return self.ptr.ByteSize()
@@ -116,15 +117,18 @@ cdef class Row:
             return self.ptr.id()
 
     def observed_size(self):
-        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE
+        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE,\
+            "invalid sparsity type"
         return self.ptr.data().observed().dense_size()
 
     def observed(self, int index):
-        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE
+        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE,\
+            "invalid sparsity type"
         return self.ptr.data().observed().dense(index)
 
     def add_observed(self, bool value):
-        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE
+        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE,\
+            "invalid sparsity type"
         self.ptr.data().observed().add_dense(value)
 
     def iter_observed(self):

--- a/loom/cFormat.pyx
+++ b/loom/cFormat.pyx
@@ -31,13 +31,28 @@ from libc.stdint cimport uint32_t, uint64_t
 
 
 cdef extern from "loom/schema.pb.h":
-    cppclass Value_cc "protobuf::loom::ProductModel::Value":
+    ctypedef enum Sparsity "protobuf::loom::ProductValue::Observed::Sparsity":
+        SPARSITY_ALL "protobuf::loom::ProductValue::Observed::ALL"
+        SPARSITY_DENSE "protobuf::loom::ProductValue::Observed::DENSE"
+        SPARSITY_SPARSE "protobuf::loom::ProductValue::Observed::SPARSE"
+
+    cppclass Observed_cc "protobuf::loom::ProductValue::Observed":
+        Observed_cc "protobuf::loom::ProductValue::Observed" () nogil except +
+        void Clear () nogil except +
+        Sparsity sparsity () nogil except +
+        void set_sparsity (Sparsity) nogil except +
+        int dense_size () nogil except +
+        bool dense (int index) nogil except +
+        void add_dense (bool value) nogil except +
+        int sparse_size () nogil except +
+        uint32_t sparse (int index) nogil except +
+        void add_sparse (uint32_t value) nogil except +
+
+    cppclass Value_cc "protobuf::loom::ProductValue":
         Value_cc "Value" () nogil except +
         void Clear () nogil except +
         int ByteSize () nogil except +
-        int observed_size() nogil except +
-        bool observed(int index) nogil except +
-        void add_observed(bool value) nogil except +
+        Observed_cc * observed "mutable_observed" () nogil except +
         int booleans_size () nogil except +
         bool booleans (int index) nogil except +
         void add_booleans (bool value) nogil except +
@@ -82,6 +97,7 @@ cdef class Row:
 
     def __cinit__(self):
         self.ptr = new Row_cc()
+        self.ptr.data().observed().set_sparsity(SPARSITY_DENSE)
 
     def __dealloc__(self):
         del self.ptr
@@ -100,13 +116,16 @@ cdef class Row:
             return self.ptr.id()
 
     def observed_size(self):
-        return self.ptr.data().observed_size()
+        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE
+        return self.ptr.data().observed().dense_size()
 
     def observed(self, int index):
-        return self.ptr.data().observed(index)
+        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE
+        return self.ptr.data().observed().dense(index)
 
     def add_observed(self, bool value):
-        self.ptr.data().add_observed(value)
+        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE
+        self.ptr.data().observed().add_dense(value)
 
     def iter_observed(self):
         cdef int i

--- a/loom/cFormat.pyx
+++ b/loom/cFormat.pyx
@@ -132,9 +132,11 @@ cdef class Row:
         self.ptr.data().observed().add_dense(value)
 
     def iter_observed(self):
+        assert self.ptr.data().observed().sparsity() == SPARSITY_DENSE,\
+            "invalid sparsity type"
         cdef int i
-        for i in xrange(self.observed_size()):
-            yield self.observed(i)
+        for i in xrange(self.ptr.data().observed().dense_size()):
+            yield self.ptr.data().observed().dense(i)
         raise StopIteration()
 
     def booleans_size(self):

--- a/loom/datasets.py
+++ b/loom/datasets.py
@@ -36,6 +36,7 @@ import parsable
 parsable = parsable.Parsable()
 
 
+LOOM_TEST_COST = int(os.environ.get('LOOM_TEST_COST', 100))
 FEATURE_TYPES = loom.schema.MODELS.keys()
 FEATURE_TYPES += ['mixed']
 COST = {
@@ -44,12 +45,12 @@ COST = {
 }
 
 
+def get_cell_count(config):
+    return config['row_count'] * config['feature_count'] * config['density']
+
+
 def get_cost(config):
-    cell_count = (
-        config['row_count'] *
-        config['feature_count'] *
-        config['density'])
-    return cell_count * COST.get(config['feature_type'], 1)
+    return get_cell_count(config) * COST.get(config['feature_type'], 1)
 
 
 CONFIG_VALUES = [
@@ -74,9 +75,7 @@ CONFIGS = {
 TEST_CONFIGS = [
     name
     for name, config in CONFIGS.iteritems()
-    if config['row_count'] <= 100
-    if config['feature_count'] <= 10
-    if config['row_count'] * config['feature_count'] * config['density'] < 100
+    if get_cell_count(config) < LOOM_TEST_COST
 ]
 TEST_CONFIGS.sort(key=lambda c: get_cost(CONFIGS[c]))
 

--- a/loom/datasets.py
+++ b/loom/datasets.py
@@ -45,7 +45,10 @@ COST = {
 
 
 def get_cost(config):
-    cell_count = config['row_count'] * config['feature_count']
+    cell_count = (
+        config['row_count'] *
+        config['feature_count'] *
+        config['density'])
     return cell_count * COST.get(config['feature_type'], 1)
 
 
@@ -59,7 +62,8 @@ CONFIG_VALUES = [
     for feature_type in FEATURE_TYPES
     for row_count in [10 ** r for r in [1, 2, 3, 4, 5, 6]]
     for feature_count in [10 ** c for c in [1, 2, 3, 4]]
-    for density in [0.5]
+    for density in [0.05, 0.5]
+    if density * feature_count > 1
 ]
 CONFIGS = {
     '{feature_type}-{row_count}-{feature_count}-{density}'.format(**c): c

--- a/loom/datasets.py
+++ b/loom/datasets.py
@@ -36,7 +36,7 @@ import parsable
 parsable = parsable.Parsable()
 
 
-FEATURE_TYPES = loom.schema.FEATURE_TYPES.keys()
+FEATURE_TYPES = loom.schema.MODELS.keys()
 FEATURE_TYPES += ['mixed']
 COST = {
     'gp': 10,

--- a/loom/datasets.py
+++ b/loom/datasets.py
@@ -63,7 +63,7 @@ CONFIG_VALUES = [
     for row_count in [10 ** r for r in [1, 2, 3, 4, 5, 6]]
     for feature_count in [10 ** c for c in [1, 2, 3, 4]]
     for density in [0.05, 0.5]
-    if density * feature_count > 1
+    if density * row_count > 1
 ]
 CONFIGS = {
     '{feature_type}-{row_count}-{feature_count}-{density}'.format(**c): c

--- a/loom/datasets.py
+++ b/loom/datasets.py
@@ -71,6 +71,15 @@ CONFIGS = {
     if get_cost(c) <= 10 ** 7
 }
 
+TEST_CONFIGS = [
+    name
+    for name, config in CONFIGS.iteritems()
+    if config['row_count'] <= 100
+    if config['feature_count'] <= 10
+    if config['row_count'] * config['feature_count'] * config['density'] < 100
+]
+TEST_CONFIGS.sort(key=lambda c: get_cost(CONFIGS[c]))
+
 
 @parsable.command
 def generate():
@@ -78,6 +87,15 @@ def generate():
     Generate synthetic datasets for testing and benchmarking.
     '''
     configs = sorted(CONFIGS.keys(), key=(lambda c: -get_cost(CONFIGS[c])))
+    parallel_map(generate_one, configs)
+
+
+@parsable.command
+def generate_test():
+    '''
+    Generate small synthetic datasets for testing.
+    '''
+    configs = sorted(TEST_CONFIGS, key=(lambda c: -get_cost(CONFIGS[c])))
     parallel_map(generate_one, configs)
 
 

--- a/loom/format.py
+++ b/loom/format.py
@@ -136,7 +136,7 @@ def load_encoder(encoder):
     elif model in ['dd', 'dpd']:
         encode = encoder['symbols'].__getitem__
     else:
-        encode = loom.schema.FEATURE_TYPES[model].Value
+        encode = loom.schema.MODELS[model].Value
     return encode
 
 
@@ -192,7 +192,7 @@ def _make_encoder_builders_dir(schema_in, rows_in):
 
 
 def get_encoder_rank(encoder):
-    rank = loom.schema.FEATURE_TYPE_RANK[encoder['model']]
+    rank = loom.schema.MODEL_RANK[encoder['model']]
     params = None
     if encoder['model'] == 'dd':
         # dd features must be ordered by increasing dimension
@@ -232,8 +232,7 @@ def make_fake_encoding(model_in, rows_in, schema_out, encoding_out):
     schema = {}
     for kind in cross_cat.kinds:
         featureid = iter(kind.featureids)
-        for module in loom.schema.FEATURES:
-            model = module.__name__.split('.')[-1]
+        for model in loom.schema.MODELS.iterkeys():
             for shared in getattr(kind.product_model, model):
                 feature_name = '{:06d}'.format(featureid.next())
                 schema[feature_name] = model

--- a/loom/format.py
+++ b/loom/format.py
@@ -357,7 +357,9 @@ def export_rows(encoding_in, rows_in, rows_csv_out, chunk_size=1000000):
     try:
         empty = None
         for i in xrange(MAX_CHUNK_COUNT):
-            file_out = os.path.join(rows_csv_out, 'rows_{:06d}.csv'.format(i))
+            file_out = os.path.join(
+                rows_csv_out,
+                'rows_{:06d}.csv.gz'.format(i))
             with open_compressed(file_out, 'wb') as f:
                 writer = csv.writer(f)
                 writer.writerow(header)

--- a/loom/generate.py
+++ b/loom/generate.py
@@ -76,12 +76,12 @@ def generate_kinds(feature_count):
 
 def generate_features(feature_count, feature_type='mixed'):
     if feature_type == 'mixed':
-        feature_types = loom.schema.FEATURE_TYPES.keys()
+        feature_types = loom.schema.MODELS.keys()
     else:
         feature_types = [feature_type]
     features = []
     for feature_type in feature_types:
-        module = loom.schema.FEATURE_TYPES[feature_type]
+        module = loom.schema.MODELS[feature_type]
         for example in module.EXAMPLES:
             features.append(module.Shared.from_dict(example['shared']))
     features *= (feature_count + len(features) - 1) / len(features)
@@ -96,7 +96,7 @@ def import_features(encoders):
     features = []
     for encoder in encoders:
         feature_type = encoder['model']
-        feature = loom.schema.FEATURE_TYPES[feature_type].Shared()
+        feature = loom.schema.MODELS[feature_type].Shared()
         if feature_type in ['bb', 'gp', 'nich']:
             raw = sample_grid(loom.hyperprior.DEFAULTS[feature_type])
         elif feature_type == 'dpd':

--- a/loom/schema.py
+++ b/loom/schema.py
@@ -25,20 +25,16 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from collections import OrderedDict
 from distributions.lp.models import bb, dd, dpd, gp, nich
 #from distributions.dbg.models import bb, dd, dpd, gp, nich  # DEBUG
 
-FEATURES = [bb, dd, dpd, gp, nich]
+MODELS = OrderedDict([
+    (module.__name__.split('.')[-1], module)
+    for module in [bb, dd, dpd, gp, nich]
+])
 
-FEATURE_TYPES = {
-    module.__name__.split('.')[-1]: module
-    for module in FEATURES
-}
-
-FEATURE_TYPE_RANK = {
-    module.__name__.split('.')[-1]: i
-    for i, module in enumerate(FEATURES)
-}
+MODEL_RANK = {name: i for i, name in enumerate(MODELS.iterkeys())}
 
 MODEL_TO_DATATYPE = {
     'bb': 'booleans',
@@ -59,7 +55,7 @@ def get_feature_rank(shared):
         param = len(shared.dump()['alphas'])
     else:
         param = None
-    return (FEATURE_TYPE_RANK[feature_type], param)
+    return (MODEL_RANK[feature_type], param)
 
 
 def get_canonical_feature_ordering(named_features):

--- a/loom/test/test_benchmark.py
+++ b/loom/test/test_benchmark.py
@@ -26,12 +26,14 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import loom.benchmark
+import loom.datasets
 
-DATASET = 'dd-10-10-0.5'
+DATASET = 'bb-10-10-0.5'
 
 
 def test_generate():
-    loom.benchmark.generate(profile=None)
+    config = loom.datasets.CONFIGS[DATASET]
+    loom.benchmark.generate(profile=None, **config)
 
 
 def test_ingest():

--- a/loom/test/test_format.py
+++ b/loom/test/test_format.py
@@ -95,7 +95,7 @@ def test_export_rows(encoding, rows, **unused):
             rows_csv_out=rows_csv,
             chunk_size=51)
         assert_found(rows_csv)
-        assert_found(os.path.join(rows_csv, 'rows_000000.csv'))
+        assert_found(os.path.join(rows_csv, 'rows_000000.csv.gz'))
         loom.format.import_rows(
             encoding_in=encoding,
             rows_csv_in=rows_csv,

--- a/loom/test/test_generate.py
+++ b/loom/test/test_generate.py
@@ -30,7 +30,7 @@ from distributions.fileutil import tempdir
 from loom.test.util import for_each_dataset, CLEANUP_ON_ERROR, assert_found
 import loom.generate
 
-FEATURE_TYPES = loom.schema.FEATURE_TYPES.keys()
+FEATURE_TYPES = loom.schema.MODELS.keys()
 FEATURE_TYPES += ['mixed']
 
 

--- a/loom/test/test_posterior_enum.py
+++ b/loom/test/test_posterior_enum.py
@@ -35,7 +35,6 @@ import numpy.random
 from distributions.tests.util import seed_all
 from distributions.util import scores_to_probs
 from distributions.io.stream import protobuf_stream_load, protobuf_stream_dump
-from distributions.lp.models import bb, dd, dpd, gp, nich
 from distributions.lp.clustering import PitmanYor
 from distributions.util import multinomial_goodness_of_fit
 from loom.util import tempdir
@@ -45,20 +44,12 @@ import loom.util
 import parsable
 parsable = parsable.Parsable()
 
-assert bb and dd and dpd and gp and nich  # pacify pyflakes
-
 TRUNCATE_COUNT = 32
 MIN_GOODNESS_OF_FIT = 5e-4
 SCORE_TOL = 1e-1  # FIXME why does this need to be so large?
 SEED = 123
 
-FEATURE_TYPES = {
-    'bb': bb,
-    'dd': dd,
-    'dpd': dpd,
-    'gp': gp,
-    'nich': nich,
-}
+FEATURE_TYPES = loom.schema.MODELS.copy()
 
 DENSITIES = [
     1.0,

--- a/loom/test/test_posterior_enum.py
+++ b/loom/test/test_posterior_enum.py
@@ -635,10 +635,12 @@ def test_generate_rows():
 
 def serialize_rows(table):
     message = loom.schema_pb2.Row()
+    sparsity = loom.schema_pb2.ProductValue.Observed.DENSE
     for i, values in enumerate(table):
+        message.data.observed.sparsity = sparsity
         message.id = i
         for value in values:
-            message.data.observed.append(value is not None)
+            message.data.observed.dense.append(value is not None)
             if value is None:
                 pass
             elif isinstance(value, bool):

--- a/loom/test/test_query.py
+++ b/loom/test/test_query.py
@@ -31,7 +31,7 @@ from nose.tools import assert_false, assert_true, assert_equal
 from distributions.dbg.random import sample_bernoulli
 from distributions.fileutil import tempdir
 from distributions.io.stream import open_compressed
-from loom.schema_pb2 import CrossCat, Query
+from loom.schema_pb2 import ProductValue, CrossCat, Query
 from loom.test.util import for_each_dataset, CLEANUP_ON_ERROR
 import loom.query
 
@@ -65,8 +65,10 @@ def get_example_requests(model):
     for i, observed in enumerate(observeds):
         request = Query.Request()
         request.id = "example-{}".format(i)
-        request.sample.data.observed[:] = none_observed
-        request.sample.to_sample[:] = observed
+        request.sample.data.observed.sparsity = ProductValue.Observed.DENSE
+        request.sample.data.observed.dense[:] = none_observed
+        request.sample.to_sample.sparsity = ProductValue.Observed.DENSE
+        request.sample.to_sample.dense[:] = observed
         request.sample.sample_count = 1
         requests.append(request)
 
@@ -101,7 +103,9 @@ def test_server(model, groups, **unused):
             for request in requests:
                 req = Query.Request()
                 req.id = request.id
-                req.score.data.observed[:] = request.sample.data.observed[:]
+                req.score.data.observed.sparsity = ProductValue.Observed.DENSE
+                req.score.data.observed.dense[:] =\
+                    request.sample.data.observed.dense[:]
                 res = server.call_protobuf(req)
                 assert_equal(req.id, res.id)
                 assert_false(hasattr(req, 'error'))

--- a/loom/test/test_query.py
+++ b/loom/test/test_query.py
@@ -49,14 +49,17 @@ def get_example_requests(model):
     for kind in cross_cat.kinds:
         fs = iter(kind.featureids)
         for model in loom.schema.MODELS.iterkeys():
-            for f, shared in izip(fs, getattr(kind.product_model, model)):
+            for shared in getattr(kind.product_model, model):
+                f = fs.next()
                 if model == 'dd':
-                    nontrivials[f] = (len(shared.alphas) > 0)
+                    if len(shared.alphas) == 0:
+                        nontrivials[f] = False
                 elif model == 'dpd':
-                    nontrivials[f] = (len(shared.betas) > 0)
-
+                    if len(shared.betas) == 0:
+                        nontrivials[f] = False
     all_observed = nontrivials[:]
     none_observed = [False] * feature_count
+
     observeds = []
     observeds.append(all_observed)
     for f, nontrivial in izip(featureids, nontrivials):

--- a/loom/test/test_runner.py
+++ b/loom/test/test_runner.py
@@ -262,7 +262,7 @@ def test_posterior_enum(rows, init, **unused):
 
 
 @for_each_dataset
-def test_generate(init, **unused):
+def test_generate(model, **unused):
     for row_count in [0, 1, 100]:
         for density in [0.0, 0.5, 1.0]:
             with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
@@ -281,7 +281,7 @@ def test_generate(init, **unused):
                 groups_out = os.path.abspath('groups')
                 loom.runner.generate(
                     config_in=config_in,
-                    model_in=init,
+                    model_in=model,
                     rows_out=rows_out,
                     model_out=model_out,
                     groups_out=groups_out,

--- a/loom/test/util.py
+++ b/loom/test/util.py
@@ -41,14 +41,6 @@ def assert_found(*filenames):
 
 CLEANUP_ON_ERROR = int(os.environ.get('CLEANUP_ON_ERROR', 1))
 
-TEST_CONFIGS = [
-    name
-    for name, config in loom.datasets.CONFIGS.iteritems()
-    if config['row_count'] <= 100
-    if config['feature_count'] <= 100
-    if config['row_count'] * config['feature_count'] * config['density'] < 1000
-]
-
 
 def for_each_dataset(fun):
     @functools.wraps(fun)
@@ -63,7 +55,7 @@ def for_each_dataset(fun):
 
     @functools.wraps(fun)
     def test_all():
-        for dataset in TEST_CONFIGS:
+        for dataset in loom.datasets.TEST_CONFIGS:
             yield test_one, dataset
 
     return test_all

--- a/loom/test/util.py
+++ b/loom/test/util.py
@@ -46,6 +46,7 @@ TEST_CONFIGS = [
     for name, config in loom.datasets.CONFIGS.iteritems()
     if config['row_count'] <= 100
     if config['feature_count'] <= 100
+    if config['row_count'] * config['feature_count'] * config['density'] < 1000
 ]
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set_source_files_properties(schema.pb.cc
 add_library(loom
   loom.cc
   logger.cc
+  product_value.cc
   product_model.cc
   cross_cat.cc
   assignments.cc

--- a/src/cat_pipeline.hpp
+++ b/src/cat_pipeline.hpp
@@ -71,7 +71,7 @@ private:
         bool add;
         std::vector<char> raw;
         protobuf::Row row;
-        std::vector<protobuf::ProductModel::Value> partial_values;
+        std::vector<ProductModel::Value> partial_values;
     };
 
     struct ThreadState

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -30,6 +30,8 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <unordered_set>
+#include <unordered_map>
 #include <utility>
 #include <algorithm>
 #include <distributions/random_fwd.hpp>
@@ -182,6 +184,35 @@ inline std::ostream & operator<< (
         const distributions::SparseCounter<Key, Value> & map)
 {
     return print_map(os, map);
+}
+
+template<class Set>
+inline std::ostream & print_set (
+        std::ostream & os,
+        const Set & set)
+{
+    std::vector<typename Set::value_type> sorted;
+    for (auto & i : set) {
+        sorted.push_back(i);
+    }
+    if (sorted.empty()) {
+        return os << "{}";
+    } else {
+        std::sort(sorted.begin(), sorted.end());
+        os << '{' << sorted[0];
+        for (size_t i = 1; i < sorted.size(); ++i) {
+            os << ',' << sorted[i];
+        }
+        return os << '}';
+    }
+}
+
+template<class Value>
+inline std::ostream & operator<< (
+        std::ostream & os,
+        const std::unordered_set<Value> & set)
+{
+    return print_set(os, set);
 }
 
 } // namespace loom

--- a/src/cross_cat.cc
+++ b/src/cross_cat.cc
@@ -88,6 +88,8 @@ void CrossCat::model_load (const char * filename)
             "feature " << featureid << " appears in no kind");
     }
 
+    splitter.init(schema, featureid_to_kindid, kinds.size());
+
     topology.protobuf_load(message.topology());
 
     hyper_prior = message.hyper_prior();

--- a/src/cross_cat.cc
+++ b/src/cross_cat.cc
@@ -88,11 +88,11 @@ void CrossCat::model_load (const char * filename)
             "feature " << featureid << " appears in no kind");
     }
 
-    splitter.init(schema, featureid_to_kindid, kinds.size());
-
     topology.protobuf_load(message.topology());
 
     hyper_prior = message.hyper_prior();
+
+    update();
 }
 
 void CrossCat::model_dump (const char * filename) const

--- a/src/cross_cat.hpp
+++ b/src/cross_cat.hpp
@@ -136,6 +136,7 @@ inline void CrossCat::validate () const
         LOOM_ASSERT_EQ(schema, expected_schema);
     }
     if (LOOM_DEBUG_LEVEL >= 2) {
+        LOOM_ASSERT_EQ(splitter.full_to_part, featureid_to_kindid);
         for (size_t f = 0; f < featureid_to_kindid.size(); ++f) {
             size_t k = featureid_to_kindid[f];
             const auto & featureids = kinds[k].featureids;

--- a/src/cross_cat.hpp
+++ b/src/cross_cat.hpp
@@ -38,7 +38,7 @@ namespace loom
 
 struct CrossCat : noncopyable
 {
-    typedef protobuf::ProductModel::Value Value;
+    typedef ProductModel::Value Value;
     typedef ProductModel::FastMixture ProductMixture;
     struct Kind
     {
@@ -47,7 +47,8 @@ struct CrossCat : noncopyable
         std::unordered_set<size_t> featureids;
     };
 
-    protobuf::ValueSchema schema;
+    ValueSchema schema;
+    ValueSplitter splitter;
     protobuf::HyperPrior hyper_prior;
     Clustering::Shared topology;
     distributions::Packed_<Kind> kinds;
@@ -77,7 +78,6 @@ struct CrossCat : noncopyable
             const Value & full_value,
             std::vector<Value> & partial_values) const;
 
-    struct ValueJoiner;
     void value_join (
             Value & full_value,
             const std::vector<Value> & partial_values) const;
@@ -88,19 +88,14 @@ struct CrossCat : noncopyable
 
 private:
 
-    void validate (const Value & full_value) const;
-    void validate (const std::vector<Value> & partial_values) const;
-
     std::string get_mixture_filename (
             const char * dirname,
             size_t kindid) const;
-
-    struct value_split_fun;
-    struct value_split_observed_fun;
-    struct value_join_fun;
 };
 
-inline void CrossCat::mixture_init_unobserved (size_t empty_group_count, rng_t & rng)
+inline void CrossCat::mixture_init_unobserved (
+        size_t empty_group_count,
+        rng_t & rng)
 {
     const std::vector<int> counts(empty_group_count, 0);
     for (auto & kind : kinds) {
@@ -108,170 +103,32 @@ inline void CrossCat::mixture_init_unobserved (size_t empty_group_count, rng_t &
     }
 }
 
-struct CrossCat::value_split_fun
-{
-    const CrossCat & cross_cat;
-    const Value & full_value;
-    std::vector<Value> & partial_values;
-    size_t absolute_pos;
-
-    template<class FieldType>
-    inline void operator() (FieldType *, size_t size)
-    {
-        typedef protobuf::Fields<FieldType> Fields;
-        const auto & full_fields = Fields::get(full_value);
-        for (size_t i = 0, packed_pos = 0; i < size; ++i, ++absolute_pos) {
-            auto kindid = cross_cat.featureid_to_kindid[absolute_pos];
-            auto & partial_value = partial_values[kindid];
-            bool observed = full_value.observed(absolute_pos);
-            partial_value.add_observed(observed);
-            if (observed) {
-                Fields::get(partial_value).Add(full_fields.Get(packed_pos++));
-            }
-        }
-    }
-};
-
 inline void CrossCat::value_split (
         const Value & full_value,
         std::vector<Value> & partial_values) const
 {
-    validate(full_value);
-
-    partial_values.resize(kinds.size());
-    for (auto & partial_value : partial_values) {
-        partial_value.Clear();
-    }
-    value_split_fun fun = {* this, full_value, partial_values, 0};
-    schema.for_each_datatype(fun);
-
-    if (LOOM_DEBUG_LEVEL >= 1) {
-        size_t feature_count = featureid_to_kindid.size();
-        LOOM_ASSERT_EQ(fun.absolute_pos, feature_count);
-    }
-
-    validate(partial_values);
+    splitter.split(full_value, partial_values);
 }
-
-struct CrossCat::value_split_observed_fun
-{
-    const CrossCat & cross_cat;
-    const Value & full_value;
-    std::vector<Value> & partial_values;
-    size_t absolute_pos;
-
-    template<class FieldType>
-    inline void operator() (FieldType *, size_t size)
-    {
-        for (size_t i = 0; i < size; ++i, ++absolute_pos) {
-            auto kindid = cross_cat.featureid_to_kindid[absolute_pos];
-            auto & partial_value = partial_values[kindid];
-            bool observed = full_value.observed(absolute_pos);
-            partial_value.add_observed(observed);
-        }
-    }
-};
 
 inline void CrossCat::value_split_observed (
         const Value & full_value,
         std::vector<Value> & partial_values) const
 {
-    partial_values.resize(kinds.size());
-    for (auto & partial_value : partial_values) {
-        partial_value.Clear();
-    }
-    value_split_observed_fun fun = {* this, full_value, partial_values, 0};
-    schema.for_each_datatype(fun);
-
-    if (LOOM_DEBUG_LEVEL >= 1) {
-        size_t feature_count = featureid_to_kindid.size();
-        LOOM_ASSERT_EQ(fun.absolute_pos, feature_count);
-    }
+    splitter.split_observed(full_value, partial_values);
 }
-
-struct CrossCat::value_join_fun
-{
-    const CrossCat & cross_cat;
-    std::vector<size_t> & absolute_pos_list;
-    std::vector<size_t> & packed_pos_list;
-    Value & full_value;
-    const std::vector<Value> & partial_values;
-    size_t featureid;
-
-    template<class FieldType>
-    void operator() (FieldType *, size_t size)
-    {
-        if (size) {
-            typedef protobuf::Fields<FieldType> Fields;
-            auto & full_fields = Fields::get(full_value);
-            std::fill(packed_pos_list.begin(), packed_pos_list.end(), 0);
-            for (size_t end = featureid + size; featureid < end; ++featureid) {
-                auto kindid = cross_cat.featureid_to_kindid[featureid];
-                auto & partial_value = partial_values[kindid];
-                auto & absolute_pos = absolute_pos_list[kindid];
-                bool observed = partial_value.observed(absolute_pos++);
-                full_value.add_observed(observed);
-                if (observed) {
-                    auto & packed_pos = packed_pos_list[kindid];
-                    auto & partial_fields = Fields::get(partial_value);
-                    full_fields.Add(partial_fields.Get(packed_pos++));
-                }
-            }
-        }
-    }
-};
-
-struct CrossCat::ValueJoiner
-{
-    ValueJoiner (const CrossCat & cross_cat) : cross_cat_(cross_cat) {}
-
-    void operator() (
-            Value & full_value,
-            const std::vector<Value> & partial_values)
-    {
-        //LOOM_DEBUG(partial_values);
-        cross_cat_.validate(partial_values);
-
-        full_value.Clear();
-        absolute_pos_list_.clear();
-        absolute_pos_list_.resize(cross_cat_.kinds.size(), 0);
-        packed_pos_list_.resize(cross_cat_.kinds.size());
-        CrossCat::value_join_fun fun = {
-            cross_cat_,
-            absolute_pos_list_,
-            packed_pos_list_,
-            full_value,
-            partial_values,
-            0};
-        cross_cat_.schema.for_each_datatype(fun);
-
-        if (LOOM_DEBUG_LEVEL >= 1) {
-            size_t feature_count = cross_cat_.featureid_to_kindid.size();
-            LOOM_ASSERT_EQ(fun.featureid, feature_count);
-        }
-
-        cross_cat_.validate(full_value);
-    }
-
-private:
-
-    const CrossCat & cross_cat_;
-    std::vector<size_t> absolute_pos_list_;
-    std::vector<size_t> packed_pos_list_;
-};
 
 inline void CrossCat::value_join (
         Value & full_value,
         const std::vector<Value> & partial_values) const
 {
-    ValueJoiner(* this)(full_value, partial_values);
+    splitter.join(full_value, partial_values);
 }
 
 inline void CrossCat::validate () const
 {
     if (LOOM_DEBUG_LEVEL >= 1) {
         LOOM_ASSERT_LT(0, schema.total_size());
-        protobuf::ValueSchema expected_schema;
+        ValueSchema expected_schema;
         for (const auto & kind : kinds) {
             kind.mixture.validate(kind.model);
             expected_schema += kind.model.schema;
@@ -299,24 +156,6 @@ inline void CrossCat::validate () const
         }
         for (size_t k = 1; k < kinds.size(); ++k) {
             LOOM_ASSERT_EQ(row_counts[k], row_counts[0]);
-        }
-    }
-}
-
-inline void CrossCat::validate (const Value & full_value) const
-{
-    if (LOOM_DEBUG_LEVEL >= 2) {
-        schema.validate(full_value);
-    }
-}
-
-inline void CrossCat::validate (const std::vector<Value> & partial_values) const
-{
-    if (LOOM_DEBUG_LEVEL >= 2) {
-        const size_t kind_count = kinds.size();
-        LOOM_ASSERT_EQ(partial_values.size(), kind_count);
-        for (size_t k = 0; k < kind_count; ++k) {
-            kinds[k].model.schema.validate(partial_values[k]);
         }
     }
 }

--- a/src/cross_cat.hpp
+++ b/src/cross_cat.hpp
@@ -76,8 +76,8 @@ struct CrossCat : noncopyable
             const Value & full_value,
             std::vector<Value> & partial_values) const;
 
-    void value_split_observed (
-            const Value & full_value,
+    void observed_split (
+            const Value::Observed & full_observed,
             std::vector<Value> & partial_values) const;
 
     void value_join (
@@ -112,11 +112,11 @@ inline void CrossCat::value_split (
     splitter.split(full_value, partial_values);
 }
 
-inline void CrossCat::value_split_observed (
-        const Value & full_value,
+inline void CrossCat::observed_split (
+        const Value::Observed & full_observed,
         std::vector<Value> & partial_values) const
 {
-    splitter.split_observed(full_value, partial_values);
+    splitter.split_observed(full_observed, partial_values);
 }
 
 inline void CrossCat::value_join (

--- a/src/cross_cat.hpp
+++ b/src/cross_cat.hpp
@@ -70,6 +70,8 @@ struct CrossCat : noncopyable
 
     std::vector<std::vector<uint32_t>> get_sorted_groupids () const;
 
+    void update () { splitter.init(schema, featureid_to_kindid, kinds.size()); }
+
     void value_split (
             const Value & full_value,
             std::vector<Value> & partial_values) const;

--- a/src/kind_kernel.cc
+++ b/src/kind_kernel.cc
@@ -200,10 +200,7 @@ void KindKernel::init_featureless_kinds (size_t featureless_kind_count)
         add_featureless_kind();
     }
 
-    cross_cat_.splitter.init(
-        cross_cat_.schema,
-        cross_cat_.featureid_to_kindid,
-        cross_cat_.kinds.size());
+    cross_cat_.update();
 
     cross_cat_.validate();
     assignments_.validate();
@@ -230,6 +227,8 @@ void KindKernel::move_feature_to_kind (
     old_kind.featureids.erase(featureid);
     new_kind.featureids.insert(featureid);
     cross_cat_.featureid_to_kindid[featureid] = new_kindid;
+
+    cross_cat_.update();  // TODO do this less frequently
 
     cross_cat_.validate();
     assignments_.validate();

--- a/src/kind_kernel.cc
+++ b/src/kind_kernel.cc
@@ -200,6 +200,11 @@ void KindKernel::init_featureless_kinds (size_t featureless_kind_count)
         add_featureless_kind();
     }
 
+    cross_cat_.splitter.init(
+        cross_cat_.schema,
+        cross_cat_.featureid_to_kindid,
+        cross_cat_.kinds.size());
+
     cross_cat_.validate();
     assignments_.validate();
 }

--- a/src/kind_pipeline.hpp
+++ b/src/kind_pipeline.hpp
@@ -93,7 +93,7 @@ private:
         bool add;
         std::vector<char> raw;
         protobuf::Row row;
-        std::vector<protobuf::ProductModel::Value> partial_values;
+        std::vector<ProductModel::Value> partial_values;
         AtomicArray<uint_fast64_t> groupids;
     };
 

--- a/src/product_value.cc
+++ b/src/product_value.cc
@@ -198,14 +198,16 @@ void ValueSplitter::split_observed (
         std::vector<ProductValue> & partial_values) const
 {
     try {
-        validate(full_value);
-        auto sparsity = full_value.observed().sparsity();
-        LOOM_ASSERT_EQ(sparsity, ProductValue::Observed::DENSE);
+        const auto & observed = full_value.observed();
+        LOOM_ASSERT_EQ(observed.sparsity(), ProductValue::Observed::DENSE);
+        LOOM_ASSERT_EQ(observed.dense_size(), schema.total_size());
+        LOOM_ASSERT_EQ(observed.sparse_size(), 0);
 
         partial_values.resize(parts.size());
         for (auto & partial_value : partial_values) {
             partial_value.Clear();
-            partial_value.mutable_observed()->set_sparsity(sparsity);
+            partial_value.mutable_observed()->set_sparsity(
+                ProductValue::Observed::DENSE);
         }
 
         split_observed_dense_fun fun = {*this, full_value, partial_values, 0};

--- a/src/product_value.cc
+++ b/src/product_value.cc
@@ -1,0 +1,267 @@
+#include <loom/product_value.hpp>
+
+namespace loom
+{
+
+void ValueSplitter::init (
+        const ValueSchema & schema,
+        const std::vector<uint32_t> & full_to_part,
+        size_t part_count)
+{
+    LOOM_ASSERT_EQ(schema.total_size(), full_to_part.size());
+    this->schema = schema;
+    this->full_to_part = full_to_part;
+
+    parts.clear();
+    parts.resize(part_count);
+
+    detail::BlockIterator block;
+    size_t full_pos = 0;
+    for (block(schema.booleans_size); block.ok(full_pos); ++full_pos) {
+        auto & part = parts[full_to_part[full_pos]];
+        part.part_to_full.push_back(full_pos);
+        part.schema.booleans_size += 1;
+    }
+    for (block(schema.counts_size); block.ok(full_pos); ++full_pos) {
+        auto & part = parts[full_to_part[full_pos]];
+        part.part_to_full.push_back(full_pos);
+        part.schema.counts_size += 1;
+    }
+    for (block(schema.reals_size); block.ok(full_pos); ++full_pos) {
+        auto & part = parts[full_to_part[full_pos]];
+        part.part_to_full.push_back(full_pos);
+        part.schema.reals_size += 1;
+    }
+    LOOM_ASSERT_EQ(full_pos, full_to_part.size());
+}
+
+struct ValueSplitter::split_value_all_fun
+{
+    const ValueSplitter & splitter;
+    const ProductValue & full_value;
+    std::vector<ProductValue> & partial_values;
+    detail::BlockIterator block;
+    size_t full_pos;
+
+    template<class FieldType>
+    void operator() (FieldType *, size_t size)
+    {
+        typedef protobuf::Fields<FieldType> Fields;
+        const auto & full_fields = Fields::get(full_value);
+        for (block(size); block.ok(full_pos); ++full_pos) {
+            auto partid = splitter.full_to_part[full_pos];
+            auto & partial_value = partial_values[partid];
+            Fields::get(partial_value).Add(full_fields.Get(full_pos));
+        }
+    }
+};
+
+struct ValueSplitter::split_value_dense_fun
+{
+    const ValueSplitter & splitter;
+    const ProductValue & full_value;
+    std::vector<ProductValue> & partial_values;
+    detail::BlockIterator block;
+    size_t full_pos;
+
+    template<class FieldType>
+    void operator() (FieldType *, size_t size)
+    {
+        typedef protobuf::Fields<FieldType> Fields;
+        const auto & full_fields = Fields::get(full_value);
+        for (block(size); block.ok(full_pos); ++full_pos) {
+            auto partid = splitter.full_to_part[full_pos];
+            auto & partial_value = partial_values[partid];
+            bool observed = full_value.observed().dense(full_pos);
+            partial_value.mutable_observed()->add_dense(observed);
+            if (observed) {
+                Fields::get(partial_value).Add(
+                    full_fields.Get(block.get(full_pos)));
+            }
+        }
+    }
+};
+
+struct ValueSplitter::split_value_sparse_fun
+{
+    const ValueSplitter & splitter;
+    const ProductValue & full_value;
+    std::vector<ProductValue> & partial_values;
+    detail::BlockIterator block;
+    decltype(full_value.observed().sparse().begin()) i;
+    decltype(full_value.observed().sparse().begin()) end;
+
+    template<class FieldType>
+    void operator() (FieldType *, size_t size)
+    {
+        typedef protobuf::Fields<FieldType> Fields;
+        const auto & full_fields = Fields::get(full_value);
+        for (block(size); i != end and block.ok(*i); ++i) {
+            auto full_pos = *i;
+            auto partid = splitter.full_to_part[full_pos];
+            auto part_pos = splitter.parts[partid].part_to_full[full_pos];
+            auto & partial_value = partial_values[partid];
+            partial_value.mutable_observed()->add_sparse(part_pos);
+            Fields::get(partial_value).Add(
+                full_fields.Get(block.get(full_pos)));
+        }
+    }
+};
+
+void ValueSplitter::split (
+        const ProductValue & full_value,
+        std::vector<ProductValue> & partial_values) const
+{
+    validate(full_value);
+
+    partial_values.resize(parts.size());
+    auto sparsity = full_value.observed().sparsity();
+    for (auto & partial_value : partial_values) {
+        partial_value.Clear();
+        partial_value.mutable_observed()->set_sparsity(sparsity);
+    }
+
+    switch (sparsity) {
+        case ProductValue::Observed::ALL: {
+            split_value_all_fun fun = {
+                *this,
+                full_value,
+                partial_values,
+                detail::BlockIterator(),
+                0};
+            schema.for_each_datatype(fun);
+            LOOM_ASSERT1(
+                fun.full_pos == full_to_part.size(),
+                "programmer error");
+        } break;
+
+        case ProductValue::Observed::DENSE: {
+            split_value_dense_fun fun = {
+                *this,
+                full_value,
+                partial_values,
+                detail::BlockIterator(),
+                0};
+            schema.for_each_datatype(fun);
+            LOOM_ASSERT1(
+                fun.full_pos == full_to_part.size(),
+                "programmer error");
+        } break;
+
+        case ProductValue::Observed::SPARSE: {
+            split_value_sparse_fun fun = {
+                *this,
+                full_value,
+                partial_values,
+                detail::BlockIterator(),
+                full_value.observed().sparse().begin(),
+                full_value.observed().sparse().end()};
+            schema.for_each_datatype(fun);
+            LOOM_ASSERT1(fun.i == fun.end, "programmer error");
+        } break;
+    }
+
+    validate(partial_values);
+}
+
+struct ValueSplitter::split_observed_dense_fun
+{
+    const ValueSplitter & splitter;
+    const ProductValue & full_value;
+    std::vector<ProductValue> & partial_values;
+    detail::BlockIterator block;
+    size_t full_pos;
+
+    template<class FieldType>
+    void operator() (FieldType *, size_t size)
+    {
+        for (block(size); block.ok(full_pos); ++full_pos) {
+            auto partid = splitter.full_to_part[full_pos];
+            auto & partial_value = partial_values[partid];
+            bool observed = full_value.observed().dense(full_pos);
+            partial_value.mutable_observed()->add_dense(observed);
+        }
+    }
+};
+
+void ValueSplitter::split_observed (
+        const ProductValue & full_value,
+        std::vector<ProductValue> & partial_values) const
+{
+    validate(full_value);
+    auto sparsity = full_value.observed().sparsity();
+    LOOM_ASSERT_EQ(sparsity, ProductValue::Observed::DENSE);
+
+    partial_values.resize(parts.size());
+    for (auto & partial_value : partial_values) {
+        partial_value.Clear();
+        partial_value.mutable_observed()->set_sparsity(sparsity);
+    }
+
+    split_observed_dense_fun fun = {
+        *this,
+        full_value,
+        partial_values,
+        detail::BlockIterator(),
+        0};
+    schema.for_each_datatype(fun);
+    LOOM_ASSERT1(fun.full_pos == full_to_part.size(), "programmer error");
+}
+
+struct ValueSplitter::join_value_dense_fun
+{
+    const ValueSplitter & splitter;
+    ProductValue & full_value;
+    const std::vector<ProductValue> & partial_values;
+    size_t full_pos;
+
+    template<class FieldType>
+    void operator() (FieldType *, size_t size)
+    {
+        if (size) {
+            auto & absolute_pos_list = splitter.absolute_pos_list_;
+            auto & packed_pos_list = splitter.packed_pos_list_;
+            typedef protobuf::Fields<FieldType> Fields;
+            auto & full_fields = Fields::get(full_value);
+            std::fill(packed_pos_list.begin(), packed_pos_list.end(), 0);
+            for (size_t end = full_pos + size; full_pos < end; ++full_pos) {
+                auto partid = splitter.full_to_part[full_pos];
+                auto & partial_value = partial_values[partid];
+                auto & absolute_pos = absolute_pos_list[partid];
+                bool observed = partial_value.observed().dense(absolute_pos++);
+                full_value.mutable_observed()->add_dense(observed);
+                if (observed) {
+                    auto & packed_pos = packed_pos_list[partid];
+                    auto & partial_fields = Fields::get(partial_value);
+                    full_fields.Add(partial_fields.Get(packed_pos++));
+                }
+            }
+        }
+    }
+};
+
+void ValueSplitter::join (
+        ProductValue & full_value,
+        const std::vector<ProductValue> & partial_values) const
+{
+    //LOOM_DEBUG(partial_values);
+    validate(partial_values);
+    auto sparsity = partial_values[0].observed().sparsity();
+    LOOM_ASSERT_EQ(sparsity, ProductValue::Observed::DENSE);
+
+    full_value.Clear();
+    full_value.mutable_observed()->set_sparsity(sparsity);
+    absolute_pos_list_.clear();
+    absolute_pos_list_.resize(parts.size(), 0);
+    packed_pos_list_.resize(parts.size());
+    join_value_dense_fun fun = {*this, full_value, partial_values, 0};
+    schema.for_each_datatype(fun);
+
+    if (LOOM_DEBUG_LEVEL >= 1) {
+        LOOM_ASSERT_EQ(fun.full_pos, full_to_part.size());
+    }
+
+    validate(full_value);
+}
+
+} // namespace loom

--- a/src/product_value.cc
+++ b/src/product_value.cc
@@ -15,19 +15,19 @@ void ValueSplitter::init (
     parts.clear();
     parts.resize(part_count);
 
-    detail::BlockIterator block;
     size_t full_pos = 0;
-    for (block(schema.booleans_size); block.ok(full_pos); ++full_pos) {
+    size_t end;
+    for (end = full_pos + schema.booleans_size; full_pos < end; ++full_pos) {
         auto & part = parts[full_to_part[full_pos]];
         part.part_to_full.push_back(full_pos);
         part.schema.booleans_size += 1;
     }
-    for (block(schema.counts_size); block.ok(full_pos); ++full_pos) {
+    for (end = full_pos + schema.counts_size; full_pos < end; ++full_pos) {
         auto & part = parts[full_to_part[full_pos]];
         part.part_to_full.push_back(full_pos);
         part.schema.counts_size += 1;
     }
-    for (block(schema.reals_size); block.ok(full_pos); ++full_pos) {
+    for (end = full_pos + schema.reals_size; full_pos < end; ++full_pos) {
         auto & part = parts[full_to_part[full_pos]];
         part.part_to_full.push_back(full_pos);
         part.schema.reals_size += 1;
@@ -40,19 +40,21 @@ struct ValueSplitter::split_value_all_fun
     const ValueSplitter & splitter;
     const ProductValue & full_value;
     std::vector<ProductValue> & partial_values;
-    detail::BlockIterator block;
     size_t full_pos;
 
     template<class FieldType>
     void operator() (FieldType *, size_t size)
     {
         typedef protobuf::Fields<FieldType> Fields;
-        const auto & full_fields = Fields::get(full_value);
-        for (block(size); block.ok(full_pos); ++full_pos) {
+        auto full_fields = Fields::get(full_value).begin();
+        for (size_t end = full_pos + size; full_pos < end; ++full_pos) {
             auto partid = splitter.full_to_part[full_pos];
             auto & partial_value = partial_values[partid];
-            Fields::get(partial_value).Add(full_fields.Get(full_pos));
+            Fields::get(partial_value).Add(*full_fields++);
         }
+        LOOM_ASSERT1(
+            full_fields == Fields::get(full_value).end(),
+            "programmer error");
     }
 };
 
@@ -61,24 +63,25 @@ struct ValueSplitter::split_value_dense_fun
     const ValueSplitter & splitter;
     const ProductValue & full_value;
     std::vector<ProductValue> & partial_values;
-    detail::BlockIterator block;
     size_t full_pos;
 
     template<class FieldType>
     void operator() (FieldType *, size_t size)
     {
         typedef protobuf::Fields<FieldType> Fields;
-        const auto & full_fields = Fields::get(full_value);
-        for (block(size); block.ok(full_pos); ++full_pos) {
+        auto full_fields = Fields::get(full_value).begin();
+        for (size_t end = full_pos + size; full_pos < end; ++full_pos) {
             auto partid = splitter.full_to_part[full_pos];
             auto & partial_value = partial_values[partid];
             bool observed = full_value.observed().dense(full_pos);
             partial_value.mutable_observed()->add_dense(observed);
             if (observed) {
-                Fields::get(partial_value).Add(
-                    full_fields.Get(block.get(full_pos)));
+                Fields::get(partial_value).Add(*full_fields++);
             }
         }
+        LOOM_ASSERT1(
+            full_fields == Fields::get(full_value).end(),
+            "programmer error");
     }
 };
 
@@ -87,24 +90,26 @@ struct ValueSplitter::split_value_sparse_fun
     const ValueSplitter & splitter;
     const ProductValue & full_value;
     std::vector<ProductValue> & partial_values;
-    detail::BlockIterator block;
-    decltype(full_value.observed().sparse().begin()) i;
+    decltype(full_value.observed().sparse().begin()) it;
     decltype(full_value.observed().sparse().begin()) end;
+    detail::BlockIterator block;
 
     template<class FieldType>
     void operator() (FieldType *, size_t size)
     {
         typedef protobuf::Fields<FieldType> Fields;
-        const auto & full_fields = Fields::get(full_value);
-        for (block(size); i != end and block.ok(*i); ++i) {
-            auto full_pos = *i;
+        auto full_fields = Fields::get(full_value).begin();
+        for (block(size); it != end and block.ok(*it); ++it) {
+            auto full_pos = *it;
             auto partid = splitter.full_to_part[full_pos];
             auto part_pos = splitter.parts[partid].part_to_full[full_pos];
             auto & partial_value = partial_values[partid];
             partial_value.mutable_observed()->add_sparse(part_pos);
-            Fields::get(partial_value).Add(
-                full_fields.Get(block.get(full_pos)));
+            Fields::get(partial_value).Add(*full_fields++);
         }
+        LOOM_ASSERT1(
+            full_fields == Fields::get(full_value).end(),
+            "programmer error");
     }
 };
 
@@ -112,59 +117,61 @@ void ValueSplitter::split (
         const ProductValue & full_value,
         std::vector<ProductValue> & partial_values) const
 {
-    validate(full_value);
+    try {
+        validate(full_value);
 
-    partial_values.resize(parts.size());
-    auto sparsity = full_value.observed().sparsity();
-    for (auto & partial_value : partial_values) {
-        partial_value.Clear();
-        partial_value.mutable_observed()->set_sparsity(sparsity);
+        partial_values.resize(parts.size());
+        auto sparsity = full_value.observed().sparsity();
+        for (auto & partial_value : partial_values) {
+            partial_value.Clear();
+            partial_value.mutable_observed()->set_sparsity(sparsity);
+        }
+
+        switch (sparsity) {
+            case ProductValue::Observed::ALL: {
+                split_value_all_fun fun = {
+                    *this,
+                    full_value,
+                    partial_values,
+                    0};
+                schema.for_each_datatype(fun);
+                LOOM_ASSERT1(
+                    fun.full_pos == full_to_part.size(),
+                    "programmer error");
+            } break;
+
+            case ProductValue::Observed::DENSE: {
+                split_value_dense_fun fun = {
+                    *this,
+                    full_value,
+                    partial_values,
+                    0};
+                schema.for_each_datatype(fun);
+                LOOM_ASSERT1(
+                    fun.full_pos == full_to_part.size(),
+                    "programmer error");
+            } break;
+
+            case ProductValue::Observed::SPARSE: {
+                split_value_sparse_fun fun = {
+                    *this,
+                    full_value,
+                    partial_values,
+                    full_value.observed().sparse().begin(),
+                    full_value.observed().sparse().end(),
+                    detail::BlockIterator()};
+                schema.for_each_datatype(fun);
+                LOOM_ASSERT1(fun.it == fun.end, "programmer error");
+            } break;
+
+            case ProductValue::Observed::NONE:
+                break;
+        }
+
+        validate(partial_values);
+    } catch (google::protobuf::FatalException e) {
+        LOOM_ERROR(e.what());
     }
-
-    switch (sparsity) {
-        case ProductValue::Observed::ALL: {
-            split_value_all_fun fun = {
-                *this,
-                full_value,
-                partial_values,
-                detail::BlockIterator(),
-                0};
-            schema.for_each_datatype(fun);
-            LOOM_ASSERT1(
-                fun.full_pos == full_to_part.size(),
-                "programmer error");
-        } break;
-
-        case ProductValue::Observed::DENSE: {
-            split_value_dense_fun fun = {
-                *this,
-                full_value,
-                partial_values,
-                detail::BlockIterator(),
-                0};
-            schema.for_each_datatype(fun);
-            LOOM_ASSERT1(
-                fun.full_pos == full_to_part.size(),
-                "programmer error");
-        } break;
-
-        case ProductValue::Observed::SPARSE: {
-            split_value_sparse_fun fun = {
-                *this,
-                full_value,
-                partial_values,
-                detail::BlockIterator(),
-                full_value.observed().sparse().begin(),
-                full_value.observed().sparse().end()};
-            schema.for_each_datatype(fun);
-            LOOM_ASSERT1(fun.i == fun.end, "programmer error");
-        } break;
-
-        case ProductValue::Observed::NONE:
-            break;
-    }
-
-    validate(partial_values);
 }
 
 struct ValueSplitter::split_observed_dense_fun
@@ -172,13 +179,12 @@ struct ValueSplitter::split_observed_dense_fun
     const ValueSplitter & splitter;
     const ProductValue & full_value;
     std::vector<ProductValue> & partial_values;
-    detail::BlockIterator block;
     size_t full_pos;
 
     template<class FieldType>
     void operator() (FieldType *, size_t size)
     {
-        for (block(size); block.ok(full_pos); ++full_pos) {
+        for (size_t end = full_pos + size; full_pos < end; ++full_pos) {
             auto partid = splitter.full_to_part[full_pos];
             auto & partial_value = partial_values[partid];
             bool observed = full_value.observed().dense(full_pos);
@@ -191,24 +197,23 @@ void ValueSplitter::split_observed (
         const ProductValue & full_value,
         std::vector<ProductValue> & partial_values) const
 {
-    validate(full_value);
-    auto sparsity = full_value.observed().sparsity();
-    LOOM_ASSERT_EQ(sparsity, ProductValue::Observed::DENSE);
+    try {
+        validate(full_value);
+        auto sparsity = full_value.observed().sparsity();
+        LOOM_ASSERT_EQ(sparsity, ProductValue::Observed::DENSE);
 
-    partial_values.resize(parts.size());
-    for (auto & partial_value : partial_values) {
-        partial_value.Clear();
-        partial_value.mutable_observed()->set_sparsity(sparsity);
+        partial_values.resize(parts.size());
+        for (auto & partial_value : partial_values) {
+            partial_value.Clear();
+            partial_value.mutable_observed()->set_sparsity(sparsity);
+        }
+
+        split_observed_dense_fun fun = {*this, full_value, partial_values, 0};
+        schema.for_each_datatype(fun);
+        LOOM_ASSERT1(fun.full_pos == full_to_part.size(), "programmer error");
+    } catch (google::protobuf::FatalException e) {
+        LOOM_ERROR(e.what());
     }
-
-    split_observed_dense_fun fun = {
-        *this,
-        full_value,
-        partial_values,
-        detail::BlockIterator(),
-        0};
-    schema.for_each_datatype(fun);
-    LOOM_ASSERT1(fun.full_pos == full_to_part.size(), "programmer error");
 }
 
 struct ValueSplitter::join_value_dense_fun
@@ -247,24 +252,28 @@ void ValueSplitter::join (
         ProductValue & full_value,
         const std::vector<ProductValue> & partial_values) const
 {
-    //LOOM_DEBUG(partial_values);
-    validate(partial_values);
-    auto sparsity = partial_values[0].observed().sparsity();
-    LOOM_ASSERT_EQ(sparsity, ProductValue::Observed::DENSE);
+    try {
+        //LOOM_DEBUG(partial_values);
+        validate(partial_values);
+        auto sparsity = partial_values[0].observed().sparsity();
+        LOOM_ASSERT_EQ(sparsity, ProductValue::Observed::DENSE);
 
-    full_value.Clear();
-    full_value.mutable_observed()->set_sparsity(sparsity);
-    absolute_pos_list_.clear();
-    absolute_pos_list_.resize(parts.size(), 0);
-    packed_pos_list_.resize(parts.size());
-    join_value_dense_fun fun = {*this, full_value, partial_values, 0};
-    schema.for_each_datatype(fun);
+        full_value.Clear();
+        full_value.mutable_observed()->set_sparsity(sparsity);
+        absolute_pos_list_.clear();
+        absolute_pos_list_.resize(parts.size(), 0);
+        packed_pos_list_.resize(parts.size());
+        join_value_dense_fun fun = {*this, full_value, partial_values, 0};
+        schema.for_each_datatype(fun);
 
-    if (LOOM_DEBUG_LEVEL >= 1) {
-        LOOM_ASSERT_EQ(fun.full_pos, full_to_part.size());
+        if (LOOM_DEBUG_LEVEL >= 1) {
+            LOOM_ASSERT_EQ(fun.full_pos, full_to_part.size());
+        }
+
+        validate(full_value);
+    } catch (google::protobuf::FatalException e) {
+        LOOM_ERROR(e.what());
     }
-
-    validate(full_value);
 }
 
 } // namespace loom

--- a/src/product_value.cc
+++ b/src/product_value.cc
@@ -159,6 +159,9 @@ void ValueSplitter::split (
             schema.for_each_datatype(fun);
             LOOM_ASSERT1(fun.i == fun.end, "programmer error");
         } break;
+
+        case ProductValue::Observed::NONE:
+            break;
     }
 
     validate(partial_values);

--- a/src/product_value.hpp
+++ b/src/product_value.hpp
@@ -404,8 +404,7 @@ inline void read_value_dense (
             }
         }
     } else {
-        observed +=
-            model_schema.nich.size();
+        observed += model_schema.nich.size();
     }
 
     LOOM_ASSERT2(
@@ -456,25 +455,29 @@ inline void read_value (
         const ForEachFeatureType<Feature> & model_schema,
         const ProductValue & value)
 {
-    if (LOOM_DEBUG_LEVEL >= 2) {
-        value_schema.validate(value);
-    }
+    try {
+        if (LOOM_DEBUG_LEVEL >= 2) {
+            value_schema.validate(value);
+        }
 
-    switch (value.observed().sparsity()) {
-        case ProductValue::Observed::ALL:
-            read_value_all(fun, model_schema, value);
-            break;
+        switch (value.observed().sparsity()) {
+            case ProductValue::Observed::ALL:
+                read_value_all(fun, model_schema, value);
+                break;
 
-        case ProductValue::Observed::DENSE:
-            read_value_dense(fun, model_schema, value);
-            break;
+            case ProductValue::Observed::DENSE:
+                read_value_dense(fun, model_schema, value);
+                break;
 
-        case ProductValue::Observed::SPARSE:
-            read_value_sparse(fun, model_schema, value);
-            break;
+            case ProductValue::Observed::SPARSE:
+                read_value_sparse(fun, model_schema, value);
+                break;
 
-        case ProductValue::Observed::NONE:
-            break;
+            case ProductValue::Observed::NONE:
+                break;
+        }
+    } catch (google::protobuf::FatalException e) {
+        LOOM_ERROR(e.what());
     }
 }
 
@@ -610,26 +613,30 @@ inline void write_value (
         const ForEachFeatureType<Feature> & model_schema,
         ProductValue & value)
 {
-    switch (value.observed().sparsity()) {
-        case ProductValue::Observed::ALL:
-            write_value_all(fun, model_schema, value);
-            break;
+    try {
+        switch (value.observed().sparsity()) {
+            case ProductValue::Observed::ALL:
+                write_value_all(fun, model_schema, value);
+                break;
 
-        case ProductValue::Observed::DENSE:
-            write_value_dense(fun, model_schema, value);
-            break;
+            case ProductValue::Observed::DENSE:
+                write_value_dense(fun, model_schema, value);
+                break;
 
-        case ProductValue::Observed::SPARSE:
-            write_value_sparse(fun, model_schema, value);
-            break;
+            case ProductValue::Observed::SPARSE:
+                write_value_sparse(fun, model_schema, value);
+                break;
 
-        case ProductValue::Observed::NONE:
-            write_value_none(value);
-            break;
-    }
+            case ProductValue::Observed::NONE:
+                write_value_none(value);
+                break;
+        }
 
-    if (LOOM_DEBUG_LEVEL >= 2) {
-        value_schema.validate(value);
+        if (LOOM_DEBUG_LEVEL >= 2) {
+            value_schema.validate(value);
+        }
+    } catch (google::protobuf::FatalException e) {
+        LOOM_ERROR(e.what());
     }
 }
 

--- a/src/product_value.hpp
+++ b/src/product_value.hpp
@@ -84,15 +84,11 @@ struct ValueSchema
             case ProductValue::Observed::ALL:
                 return total_size();
 
-            case ProductValue::Observed::DENSE: {
-                size_t count = 0;
-                for (auto i : observed.dense()) {
-                    if (i) {
-                        ++count;
-                    }
-                }
-                return count;
-            }
+            case ProductValue::Observed::DENSE:
+                return std::count_if(
+                    observed.dense().begin(),
+                    observed.dense().end(),
+                    [](bool i){ return i; });
 
             case ProductValue::Observed::SPARSE:
                 return observed.sparse_size();
@@ -717,7 +713,7 @@ struct ValueSplitter
             std::vector<ProductValue> & partial_values) const;
 
     void split_observed (
-            const ProductValue & full_value,
+            const ProductValue::Observed & full_observed,
             std::vector<ProductValue> & partial_values) const;
 
     // not thread safe

--- a/src/product_value.hpp
+++ b/src/product_value.hpp
@@ -128,8 +128,8 @@ struct ValueSchema
                 return;
 
             case ProductValue::Observed::DENSE:
-                LOOM_ASSERT_EQ(observed.dense_size(), 0);
-                LOOM_ASSERT_LE(observed.sparse_size(), total_size());
+                LOOM_ASSERT_EQ(observed.dense_size(), total_size());
+                LOOM_ASSERT_EQ(observed.sparse_size(), 0);
                 LOOM_ASSERT_LE(value.booleans_size(), booleans_size);
                 LOOM_ASSERT_LE(value.counts_size(), counts_size);
                 LOOM_ASSERT_LE(value.reals_size(), reals_size);
@@ -137,8 +137,8 @@ struct ValueSchema
                 return;
 
             case ProductValue::Observed::SPARSE:
-                LOOM_ASSERT_EQ(observed.dense_size(), total_size());
-                LOOM_ASSERT_EQ(observed.sparse_size(), 0);
+                LOOM_ASSERT_EQ(observed.dense_size(), 0);
+                LOOM_ASSERT_LE(observed.sparse_size(), total_size());
                 LOOM_ASSERT_LE(value.booleans_size(), booleans_size);
                 LOOM_ASSERT_LE(value.counts_size(), counts_size);
                 LOOM_ASSERT_LE(value.reals_size(), reals_size);
@@ -160,16 +160,16 @@ struct ValueSchema
                     and value.reals_size() == reals_size;
 
             case ProductValue::Observed::DENSE:
-                return observed.dense_size() == 0
-                    and observed.sparse_size() <= total_size()
+                return observed.dense_size() == total_size()
+                    and observed.sparse_size() == 0
                     and value.booleans_size() <= booleans_size
                     and value.counts_size() <= counts_size
                     and value.reals_size() <= reals_size
                     and observed_count(value) <= total_size(value);
 
             case ProductValue::Observed::SPARSE:
-                return observed.dense_size() == total_size()
-                    and observed.sparse_size() == 0
+                return observed.dense_size() == 0
+                    and observed.sparse_size() <= total_size()
                     and value.booleans_size() <= booleans_size
                     and value.counts_size() <= counts_size
                     and value.reals_size() <= reals_size

--- a/src/product_value.hpp
+++ b/src/product_value.hpp
@@ -1,0 +1,657 @@
+#pragma once
+
+#include <loom/common.hpp>
+#include <loom/protobuf.hpp>
+#include <loom/models.hpp>
+
+namespace loom
+{
+
+typedef protobuf::ProductValue ProductValue;
+
+inline std::ostream & operator << (
+        std::ostream & os,
+        const ProductValue::Observed::Sparsity & sparsity)
+{
+    return os << ProductValue::Observed::Sparsity_Name(sparsity);
+}
+
+namespace detail
+{
+class BlockIterator
+{
+    size_t begin_;
+    size_t end_;
+
+public:
+
+    BlockIterator () : begin_(0), end_(0) {}
+    void operator() (size_t size)
+    {
+        begin_ = end_;
+        end_ += size;
+    }
+    bool ok (size_t i) const { return i < end_; }
+    size_t get (size_t i) const { return i - begin_; }
+};
+} // namespace detail
+
+//----------------------------------------------------------------------------
+// Schema
+
+struct ValueSchema
+{
+    size_t booleans_size;
+    size_t counts_size;
+    size_t reals_size;
+
+    ValueSchema () :
+        booleans_size(0),
+        counts_size(0),
+        reals_size(0)
+    {
+    }
+
+    size_t total_size () const
+    {
+        return booleans_size + counts_size + reals_size;
+    }
+
+    static size_t total_size (const ProductValue & value)
+    {
+        return value.booleans_size()
+            + value.counts_size()
+            + value.reals_size();
+    }
+
+    void clear ()
+    {
+        booleans_size = 0;
+        counts_size = 0;
+        reals_size = 0;
+    }
+
+    void operator+= (const ValueSchema & other)
+    {
+        booleans_size += other.booleans_size;
+        counts_size += other.counts_size;
+        reals_size += other.reals_size;
+    }
+
+    static size_t observed_count (const ProductValue & value)
+    {
+        const auto & observed = value.observed();
+        switch (observed.sparsity()) {
+            case ProductValue::Observed::ALL:
+                return total_size(value);
+
+            case ProductValue::Observed::DENSE: {
+                size_t count = 0;
+                size_t size = observed.dense_size();
+                for (size_t i = 0; i < size; ++i) {
+                    if (observed.dense(i)) {
+                        ++count;
+                    }
+                }
+                return count;
+            }
+
+            case ProductValue::Observed::SPARSE:
+                return observed.sparse_size();
+        }
+
+        return 0;  // pacify gcc
+    }
+
+    static bool is_sorted (const ProductValue & value)
+    {
+        const auto & sparse = value.observed().sparse();
+        const size_t size = sparse.size();
+        for (size_t i = 1; i < size; ++i) {
+            if (LOOM_UNLIKELY(sparse.Get(i - 1) >= sparse.Get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void validate (const ProductValue & value) const
+    {
+        const auto & observed = value.observed();
+        switch (observed.sparsity()) {
+            case ProductValue::Observed::ALL:
+                LOOM_ASSERT_EQ(observed.dense_size(), 0);
+                LOOM_ASSERT_EQ(observed.sparse_size(), 0);
+                LOOM_ASSERT_EQ(value.booleans_size(), booleans_size);
+                LOOM_ASSERT_EQ(value.counts_size(), counts_size);
+                LOOM_ASSERT_EQ(value.reals_size(), reals_size);
+                return;
+
+            case ProductValue::Observed::DENSE:
+                LOOM_ASSERT_EQ(observed.dense_size(), 0);
+                LOOM_ASSERT_LE(observed.sparse_size(), total_size());
+                LOOM_ASSERT_LE(value.booleans_size(), booleans_size);
+                LOOM_ASSERT_LE(value.counts_size(), counts_size);
+                LOOM_ASSERT_LE(value.reals_size(), reals_size);
+                LOOM_ASSERT_LE(observed_count(value), total_size(value));
+                return;
+
+            case ProductValue::Observed::SPARSE:
+                LOOM_ASSERT_EQ(observed.dense_size(), total_size());
+                LOOM_ASSERT_EQ(observed.sparse_size(), 0);
+                LOOM_ASSERT_LE(value.booleans_size(), booleans_size);
+                LOOM_ASSERT_LE(value.counts_size(), counts_size);
+                LOOM_ASSERT_LE(value.reals_size(), reals_size);
+                LOOM_ASSERT_LE(observed_count(value), total_size(value));
+                LOOM_ASSERT(is_sorted(value), "sparse value is not sorted");
+                return;
+        }
+    }
+
+    bool is_valid (const ProductValue & value) const
+    {
+        const auto & observed = value.observed();
+        switch (observed.sparsity()) {
+            case ProductValue::Observed::ALL:
+                return observed.dense_size() == 0
+                    and observed.sparse_size() == 0
+                    and value.booleans_size() == booleans_size
+                    and value.counts_size() == counts_size
+                    and value.reals_size() == reals_size;
+
+            case ProductValue::Observed::DENSE:
+                return observed.dense_size() == 0
+                    and observed.sparse_size() <= total_size()
+                    and value.booleans_size() <= booleans_size
+                    and value.counts_size() <= counts_size
+                    and value.reals_size() <= reals_size
+                    and observed_count(value) <= total_size(value);
+
+            case ProductValue::Observed::SPARSE:
+                return observed.dense_size() == total_size()
+                    and observed.sparse_size() == 0
+                    and value.booleans_size() <= booleans_size
+                    and value.counts_size() <= counts_size
+                    and value.reals_size() <= reals_size
+                    and observed_count(value) <= total_size(value)
+                    and is_sorted(value);
+        }
+
+        return false;  // pacify gcc
+    }
+
+    void normalize_small (
+            ProductValue & value,
+            float sparse_threshold = 0.1) const
+    {
+        auto & observed = * value.mutable_observed();
+        switch (observed.sparsity()) {
+            case ProductValue::Observed::ALL:
+                break;
+
+            case ProductValue::Observed::DENSE: {
+                const size_t size = total_size();
+                const size_t count = observed_count(value);
+                if (count == size) {
+                    observed.set_sparsity(ProductValue::Observed::ALL);
+                    observed.clear_dense();
+                } else if (count < sparse_threshold * size) {
+                    observed.set_sparsity(ProductValue::Observed::SPARSE);
+                    for (size_t i = 0; i < size; ++i) {
+                        if (LOOM_UNLIKELY(observed.dense(i))) {
+                            observed.add_sparse(i);
+                        }
+                    }
+                    observed.clear_dense();
+                }
+            } break;
+
+            case ProductValue::Observed::SPARSE:
+                break;
+        }
+
+        if (LOOM_DEBUG_LEVEL >= 2) {
+            validate(value);
+        }
+    }
+
+    void normalize_dense (ProductValue & value) const
+    {
+        auto & observed = * value.mutable_observed();
+        switch (observed.sparsity()) {
+            case ProductValue::Observed::ALL: {
+                observed.set_sparsity(ProductValue::Observed::DENSE);
+                const size_t size = total_size();
+                for (size_t i = 0; i < size; ++i) {
+                    observed.add_dense(true);
+                }
+            } break;
+
+            case ProductValue::Observed::DENSE:
+                break;
+
+            case ProductValue::Observed::SPARSE: {
+                observed.set_sparsity(ProductValue::Observed::DENSE);
+                const size_t size = total_size();
+                for (size_t i = 0; i < size; ++i) {
+                    observed.add_dense(false);
+                }
+                for (auto i : observed.sparse()) {
+                    observed.set_dense(i, true);
+                }
+                observed.clear_sparse();
+            } break;
+        }
+
+        if (LOOM_DEBUG_LEVEL >= 2) {
+            validate(value);
+        }
+    }
+
+    template<class Fun>
+    void for_each_datatype (Fun & fun) const
+    {
+        fun(static_cast<bool *>(nullptr), booleans_size);
+        fun(static_cast<uint32_t *>(nullptr), counts_size);
+        fun(static_cast<float *>(nullptr), reals_size);
+    }
+
+    bool operator== (const ValueSchema & other) const
+    {
+        return booleans_size == other.booleans_size
+            and counts_size == other.counts_size
+            and reals_size == other.reals_size;
+    }
+
+    friend std::ostream & operator<< (
+        std::ostream & os,
+        const ValueSchema & schema)
+    {
+        return os << "{" <<
+            schema.booleans_size << ", " <<
+            schema.counts_size << ", " <<
+            schema.reals_size << "}";
+    }
+};
+
+//----------------------------------------------------------------------------
+// Read
+
+template<class Feature, class Fun>
+inline void read_value_all (
+        Fun & fun,
+        const ForEachFeatureType<Feature> & model_schema,
+        const ProductValue & value)
+{
+    if (value.booleans_size()) {
+        for (size_t i = 0, size = model_schema.bb.size(); i < size; ++i) {
+            fun(BB::null(), i, value.booleans(i));
+        }
+    }
+
+    if (value.counts_size()) {
+        size_t packed_pos = 0;
+        for (size_t i = 0, size = model_schema.dd16.size(); i < size; ++i) {
+            fun(DD16::null(), i, value.counts(packed_pos++));
+        }
+        for (size_t i = 0, size = model_schema.dd256.size(); i < size; ++i) {
+            fun(DD256::null(), i, value.counts(packed_pos++));
+        }
+        for (size_t i = 0, size = model_schema.dpd.size(); i < size; ++i) {
+            fun(DPD::null(), i, value.counts(packed_pos++));
+        }
+        for (size_t i = 0, size = model_schema.gp.size(); i < size; ++i) {
+            fun(GP::null(), i, value.counts(packed_pos++));
+        }
+    }
+
+    if (value.reals_size()) {
+        for (size_t i = 0, size = model_schema.nich.size(); i < size; ++i) {
+            fun(NICH::null(), i, value.reals(i));
+        }
+    }
+}
+
+template<class Feature, class Fun>
+inline void read_value_dense (
+        Fun & fun,
+        const ForEachFeatureType<Feature> & model_schema,
+        const ProductValue & value)
+{
+    auto observed = value.observed().dense().begin();
+
+    if (value.booleans_size()) {
+        size_t packed_pos = 0;
+        for (size_t i = 0, size = model_schema.bb.size(); i < size; ++i) {
+            if (*observed++) {
+                fun(BB::null(), i, value.booleans(packed_pos++));
+            }
+        }
+    } else {
+        observed += model_schema.bb.size();
+    }
+
+    if (value.counts_size()) {
+        size_t packed_pos = 0;
+        for (size_t i = 0, size = model_schema.dd16.size(); i < size; ++i) {
+            if (*observed++) {
+                fun(DD16::null(), i, value.counts(packed_pos++));
+            }
+        }
+        for (size_t i = 0, size = model_schema.dd256.size(); i < size; ++i) {
+            if (*observed++) {
+                fun(DD256::null(), i, value.counts(packed_pos++));
+            }
+        }
+        for (size_t i = 0, size = model_schema.dpd.size(); i < size; ++i) {
+            if (*observed++) {
+                fun(DPD::null(), i, value.counts(packed_pos++));
+            }
+        }
+        for (size_t i = 0, size = model_schema.gp.size(); i < size; ++i) {
+            if (*observed++) {
+                fun(GP::null(), i, value.counts(packed_pos++));
+            }
+        }
+    } else {
+        observed +=
+            model_schema.dd16.size() +
+            model_schema.dd256.size() +
+            model_schema.dpd.size() +
+            model_schema.gp.size();
+    }
+
+    if (value.reals_size()) {
+        size_t packed_pos = 0;
+        for (size_t i = 0, size = model_schema.nich.size(); i < size; ++i) {
+            if (*observed++) {
+                fun(NICH::null(), i, value.reals(packed_pos++));
+            }
+        }
+    } else {
+        observed +=
+            model_schema.nich.size();
+    }
+
+    LOOM_ASSERT2(
+        observed == value.observed().dense().end(),
+        "programmer error");
+}
+
+template<class Feature, class Fun>
+inline void read_value_sparse (
+        Fun & fun,
+        const ForEachFeatureType<Feature> & model_schema,
+        const ProductValue & value)
+{
+    auto i = value.observed().sparse().begin();
+    const auto end = value.observed().sparse().end();
+    size_t packed_pos;
+    detail::BlockIterator block;
+
+    packed_pos = 0;
+    for (block(model_schema.bb.size()); i != end and block.ok(*i); ++i) {
+        fun(BB::null(), block.get(*i), value.booleans(packed_pos++));
+    }
+
+    packed_pos = 0;
+    for (block(model_schema.dd16.size()); i != end and block.ok(*i); ++i) {
+        fun(DD16::null(), block.get(*i), value.counts(packed_pos++));
+    }
+    for (block(model_schema.dd256.size()); i != end and block.ok(*i); ++i) {
+        fun(DD256::null(), block.get(*i), value.counts(packed_pos++));
+    }
+    for (block(model_schema.dpd.size()); i != end and block.ok(*i); ++i) {
+        fun(DPD::null(), block.get(*i), value.counts(packed_pos++));
+    }
+    for (block(model_schema.gp.size()); i != end and block.ok(*i); ++i) {
+        fun(GP::null(), block.get(*i), value.counts(packed_pos++));
+    }
+
+    packed_pos = 0;
+    for (block(model_schema.nich.size()); i != end and block.ok(*i); ++i) {
+        fun(NICH::null(), block.get(*i), value.reals(packed_pos++));
+    }
+}
+
+template<class Feature, class Fun>
+inline void read_value (
+        Fun & fun,
+        const ValueSchema & value_schema,
+        const ForEachFeatureType<Feature> & model_schema,
+        const ProductValue & value)
+{
+    if (LOOM_DEBUG_LEVEL >= 2) {
+        value_schema.validate(value);
+    }
+
+    switch (value.observed().sparsity()) {
+        case ProductValue::Observed::ALL:
+            read_value_all(fun, model_schema, value);
+            break;
+
+        case ProductValue::Observed::DENSE:
+            read_value_dense(fun, model_schema, value);
+            break;
+
+        case ProductValue::Observed::SPARSE:
+            read_value_sparse(fun, model_schema, value);
+            break;
+    }
+}
+
+//----------------------------------------------------------------------------
+// Write
+
+template<class Feature, class Fun>
+inline void write_value_all (
+        Fun & fun,
+        const ForEachFeatureType<Feature> & model_schema,
+        ProductValue & value)
+{
+    value.clear_booleans();
+    for (size_t i = 0, size = model_schema.bb.size(); i < size; ++i) {
+        value.add_booleans(fun(BB::null(), i));
+    }
+
+    value.clear_counts();
+    for (size_t i = 0, size = model_schema.dd16.size(); i < size; ++i) {
+        value.add_counts(fun(DD16::null(), i));
+    }
+    for (size_t i = 0, size = model_schema.dd256.size(); i < size; ++i) {
+        value.add_counts(fun(DD256::null(), i));
+    }
+    for (size_t i = 0, size = model_schema.dpd.size(); i < size; ++i) {
+        value.add_counts(fun(DPD::null(), i));
+    }
+    for (size_t i = 0, size = model_schema.gp.size(); i < size; ++i) {
+        value.add_counts(fun(GP::null(), i));
+    }
+
+    value.clear_reals();
+    for (size_t i = 0, size = model_schema.nich.size(); i < size; ++i) {
+        value.add_reals(fun(NICH::null(), i));
+    }
+}
+
+template<class Feature, class Fun>
+inline void write_value_dense (
+        Fun & fun,
+        const ForEachFeatureType<Feature> & model_schema,
+        ProductValue & value)
+{
+    auto observed = value.observed().dense().begin();
+
+    value.clear_booleans();
+    for (size_t i = 0, size = model_schema.bb.size(); i < size; ++i) {
+        if (*observed++) {
+            value.add_booleans(fun(BB::null(), i));
+        }
+    }
+
+    value.clear_counts();
+    for (size_t i = 0, size = model_schema.dd16.size(); i < size; ++i) {
+        if (*observed++) {
+            value.add_counts(fun(DD16::null(), i));
+        }
+    }
+    for (size_t i = 0, size = model_schema.dd256.size(); i < size; ++i) {
+        if (*observed++) {
+            value.add_counts(fun(DD256::null(), i));
+        }
+    }
+    for (size_t i = 0, size = model_schema.dpd.size(); i < size; ++i) {
+        if (*observed++) {
+            value.add_counts(fun(DPD::null(), i));
+        }
+    }
+    for (size_t i = 0, size = model_schema.gp.size(); i < size; ++i) {
+        if (*observed++) {
+            value.add_counts(fun(GP::null(), i));
+        }
+    }
+
+    value.clear_reals();
+    for (size_t i = 0, size = model_schema.nich.size(); i < size; ++i) {
+        if (*observed++) {
+            value.add_reals(fun(NICH::null(), i));
+        }
+    }
+
+    LOOM_ASSERT2(
+        observed == value.observed().dense().end(),
+        "programmer error");
+}
+
+template<class Feature, class Fun>
+inline void write_value_sparse (
+        Fun & fun,
+        const ForEachFeatureType<Feature> & model_schema,
+        ProductValue & value)
+{
+    auto i = value.observed().sparse().begin();
+    const auto end = value.observed().sparse().end();
+    detail::BlockIterator block;
+
+    value.clear_booleans();
+    for (block(model_schema.bb.size()); i != end and block.ok(*i); ++i) {
+       value.add_booleans(fun(BB::null(), block.get(*i)));
+    }
+
+    value.clear_counts();
+    for (block(model_schema.dd16.size()); i != end and block.ok(*i); ++i) {
+       value.add_counts(fun(DD16::null(), block.get(*i)));
+    }
+    for (block(model_schema.dd256.size()); i != end and block.ok(*i); ++i) {
+       value.add_counts(fun(DD256::null(), block.get(*i)));
+    }
+    for (block(model_schema.dpd.size()); i != end and block.ok(*i); ++i) {
+       value.add_counts(fun(DPD::null(), block.get(*i)));
+    }
+    for (block(model_schema.gp.size()); i != end and block.ok(*i); ++i) {
+       value.add_counts(fun(GP::null(), block.get(*i)));
+    }
+
+    value.clear_reals();
+    for (block(model_schema.nich.size()); i != end and block.ok(*i); ++i) {
+        value.add_reals(fun(NICH::null(), block.get(*i)));
+    }
+}
+
+template<class Feature, class Fun>
+inline void write_value (
+        Fun & fun,
+        const ValueSchema & value_schema,
+        const ForEachFeatureType<Feature> & model_schema,
+        ProductValue & value)
+{
+    switch (value.observed().sparsity()) {
+        case ProductValue::Observed::ALL:
+            write_value_all(fun, model_schema, value);
+            break;
+
+        case ProductValue::Observed::DENSE:
+            write_value_dense(fun, model_schema, value);
+            break;
+
+        case ProductValue::Observed::SPARSE:
+            write_value_sparse(fun, model_schema, value);
+            break;
+    }
+
+    if (LOOM_DEBUG_LEVEL >= 2) {
+        value_schema.validate(value);
+    }
+}
+
+//----------------------------------------------------------------------------
+// ValueSpliter
+
+struct ValueSplitter
+{
+    struct Part
+    {
+        ValueSchema schema;
+        std::vector<uint32_t> part_to_full;
+    };
+
+    ValueSchema schema;
+    std::vector<uint32_t> full_to_part;
+    std::vector<Part> parts;
+
+    void init (
+            const ValueSchema & schema,
+            const std::vector<uint32_t> & full_to_part,
+            size_t part_count);
+
+    void validate (const ProductValue & full_value) const;
+    void validate (const std::vector<ProductValue> & partial_values) const;
+
+    void split (
+            const ProductValue & full_value,
+            std::vector<ProductValue> & partial_values) const;
+
+    void split_observed (
+            const ProductValue & full_value,
+            std::vector<ProductValue> & partial_values) const;
+
+    // not thread safe
+    void join (
+            ProductValue & full_value,
+            const std::vector<ProductValue> & partial_values) const;
+
+private:
+
+    mutable std::vector<size_t> absolute_pos_list_;
+    mutable std::vector<size_t> packed_pos_list_;
+
+    struct split_value_all_fun;
+    struct split_value_dense_fun;
+    struct split_value_sparse_fun;
+    struct split_observed_dense_fun;
+    struct join_value_dense_fun;
+};
+
+inline void ValueSplitter::validate (const ProductValue & full_value) const
+{
+    if (LOOM_DEBUG_LEVEL >= 2) {
+        schema.validate(full_value);
+    }
+}
+
+inline void ValueSplitter::validate (
+        const std::vector<ProductValue> & partial_values) const
+{
+    if (LOOM_DEBUG_LEVEL >= 2) {
+        const size_t part_count = parts.size();
+        LOOM_ASSERT_EQ(partial_values.size(), part_count);
+        const auto sparsity0 = partial_values[0].observed().sparsity();
+        for (size_t i = 0; i < part_count; ++i) {
+            const auto sparsity = partial_values[i].observed().sparsity();
+            LOOM_ASSERT_EQ(sparsity, sparsity0);
+            parts[i].schema.validate(partial_values[i]);
+        }
+    }
+}
+
+} // namespace loom

--- a/src/product_value.hpp
+++ b/src/product_value.hpp
@@ -210,7 +210,10 @@ struct ValueSchema
             case ProductValue::Observed::DENSE: {
                 const size_t size = total_size();
                 const size_t count = observed_count(value);
-                if (count == size) {
+                if (count == 0) {
+                    observed.set_sparsity(ProductValue::Observed::NONE);
+                    observed.clear_dense();
+                } else if (count == size) {
                     observed.set_sparsity(ProductValue::Observed::ALL);
                     observed.clear_dense();
                 } else if (count < sparse_threshold * size) {

--- a/src/product_value.hpp
+++ b/src/product_value.hpp
@@ -78,18 +78,16 @@ struct ValueSchema
         reals_size += other.reals_size;
     }
 
-    static size_t observed_count (const ProductValue & value)
+    size_t observed_count (const ProductValue::Observed & observed) const
     {
-        const auto & observed = value.observed();
         switch (observed.sparsity()) {
             case ProductValue::Observed::ALL:
-                return total_size(value);
+                return total_size();
 
             case ProductValue::Observed::DENSE: {
                 size_t count = 0;
-                size_t size = observed.dense_size();
-                for (size_t i = 0; i < size; ++i) {
-                    if (observed.dense(i)) {
+                for (auto i : observed.dense()) {
+                    if (i) {
                         ++count;
                     }
                 }
@@ -106,9 +104,9 @@ struct ValueSchema
         return 0;  // pacify gcc
     }
 
-    static bool is_sorted (const ProductValue & value)
+    static bool is_sorted (const ProductValue::Observed & observed)
     {
-        const auto & sparse = value.observed().sparse();
+        const auto & sparse = observed.sparse();
         const size_t size = sparse.size();
         for (size_t i = 1; i < size; ++i) {
             if (LOOM_UNLIKELY(sparse.Get(i - 1) >= sparse.Get(i))) {
@@ -118,40 +116,82 @@ struct ValueSchema
         return true;
     }
 
-    void validate (const ProductValue & value) const
+    void validate (const ProductValue::Observed & observed) const
     {
-        const auto & observed = value.observed();
         switch (observed.sparsity()) {
             case ProductValue::Observed::ALL:
                 LOOM_ASSERT_EQ(observed.dense_size(), 0);
                 LOOM_ASSERT_EQ(observed.sparse_size(), 0);
+                return;
+
+            case ProductValue::Observed::DENSE:
+                LOOM_ASSERT_EQ(observed.dense_size(), total_size());
+                LOOM_ASSERT_EQ(observed.sparse_size(), 0);
+                return;
+
+            case ProductValue::Observed::SPARSE:
+                LOOM_ASSERT_EQ(observed.dense_size(), 0);
+                LOOM_ASSERT_LE(observed.sparse_size(), total_size());
+                LOOM_ASSERT(is_sorted(observed), "sparse value is not sorted");
+                return;
+
+            case ProductValue::Observed::NONE:
+                LOOM_ASSERT_EQ(observed.dense_size(), 0);
+                LOOM_ASSERT_EQ(observed.sparse_size(), 0);
+                return;
+        }
+    }
+
+    bool is_valid (const ProductValue::Observed & observed) const
+    {
+        switch (observed.sparsity()) {
+            case ProductValue::Observed::ALL:
+                return observed.dense_size() == 0
+                    and observed.sparse_size() == 0;
+
+            case ProductValue::Observed::DENSE:
+                return observed.dense_size() == total_size()
+                    and observed.sparse_size() == 0;
+
+            case ProductValue::Observed::SPARSE:
+                return observed.dense_size() == 0
+                    and observed.sparse_size() <= total_size()
+                    and is_sorted(observed);
+
+            case ProductValue::Observed::NONE:
+                return observed.dense_size() == 0
+                    and observed.sparse_size() == 0;
+        }
+
+        return false;  // pacify gcc
+    }
+
+    void validate (const ProductValue & value) const
+    {
+        const auto & observed = value.observed();
+        validate(observed);
+        switch (observed.sparsity()) {
+            case ProductValue::Observed::ALL:
                 LOOM_ASSERT_EQ(value.booleans_size(), booleans_size);
                 LOOM_ASSERT_EQ(value.counts_size(), counts_size);
                 LOOM_ASSERT_EQ(value.reals_size(), reals_size);
                 return;
 
             case ProductValue::Observed::DENSE:
-                LOOM_ASSERT_EQ(observed.dense_size(), total_size());
-                LOOM_ASSERT_EQ(observed.sparse_size(), 0);
                 LOOM_ASSERT_LE(value.booleans_size(), booleans_size);
                 LOOM_ASSERT_LE(value.counts_size(), counts_size);
                 LOOM_ASSERT_LE(value.reals_size(), reals_size);
-                LOOM_ASSERT_LE(observed_count(value), total_size(value));
+                LOOM_ASSERT_LE(observed_count(observed), total_size(value));
                 return;
 
             case ProductValue::Observed::SPARSE:
-                LOOM_ASSERT_EQ(observed.dense_size(), 0);
-                LOOM_ASSERT_LE(observed.sparse_size(), total_size());
                 LOOM_ASSERT_LE(value.booleans_size(), booleans_size);
                 LOOM_ASSERT_LE(value.counts_size(), counts_size);
                 LOOM_ASSERT_LE(value.reals_size(), reals_size);
-                LOOM_ASSERT_LE(observed_count(value), total_size(value));
-                LOOM_ASSERT(is_sorted(value), "sparse value is not sorted");
+                LOOM_ASSERT_LE(observed_count(observed), total_size(value));
                 return;
 
             case ProductValue::Observed::NONE:
-                LOOM_ASSERT_EQ(observed.dense_size(), 0);
-                LOOM_ASSERT_EQ(observed.sparse_size(), 0);
                 LOOM_ASSERT_EQ(value.booleans_size(), 0);
                 LOOM_ASSERT_EQ(value.counts_size(), 0);
                 LOOM_ASSERT_EQ(value.reals_size(), 0);
@@ -162,35 +202,29 @@ struct ValueSchema
     bool is_valid (const ProductValue & value) const
     {
         const auto & observed = value.observed();
+        if (LOOM_UNLIKELY(not is_valid(observed))) {
+            return false;
+        }
         switch (observed.sparsity()) {
             case ProductValue::Observed::ALL:
-                return observed.dense_size() == 0
-                    and observed.sparse_size() == 0
-                    and value.booleans_size() == booleans_size
+                return value.booleans_size() == booleans_size
                     and value.counts_size() == counts_size
                     and value.reals_size() == reals_size;
 
             case ProductValue::Observed::DENSE:
-                return observed.dense_size() == total_size()
-                    and observed.sparse_size() == 0
-                    and value.booleans_size() <= booleans_size
+                return value.booleans_size() <= booleans_size
                     and value.counts_size() <= counts_size
                     and value.reals_size() <= reals_size
-                    and observed_count(value) <= total_size(value);
+                    and observed_count(observed) <= total_size(value);
 
             case ProductValue::Observed::SPARSE:
-                return observed.dense_size() == 0
-                    and observed.sparse_size() <= total_size()
-                    and value.booleans_size() <= booleans_size
+                return value.booleans_size() <= booleans_size
                     and value.counts_size() <= counts_size
                     and value.reals_size() <= reals_size
-                    and observed_count(value) <= total_size(value)
-                    and is_sorted(value);
+                    and observed_count(observed) <= total_size(value);
 
             case ProductValue::Observed::NONE:
-                return observed.dense_size() == 0
-                    and observed.sparse_size() == 0
-                    and value.booleans_size() == 0
+                return value.booleans_size() == 0
                     and value.counts_size() == 0
                     and value.reals_size() == 0;
         }
@@ -199,17 +233,16 @@ struct ValueSchema
     }
 
     void normalize_small (
-            ProductValue & value,
+            ProductValue::Observed & observed,
             float sparse_threshold = 0.1) const
     {
-        auto & observed = * value.mutable_observed();
         switch (observed.sparsity()) {
             case ProductValue::Observed::ALL:
                 break;
 
             case ProductValue::Observed::DENSE: {
                 const size_t size = total_size();
-                const size_t count = observed_count(value);
+                const size_t count = observed_count(observed);
                 if (count == 0) {
                     observed.set_sparsity(ProductValue::Observed::NONE);
                     observed.clear_dense();
@@ -227,21 +260,37 @@ struct ValueSchema
                 }
             } break;
 
-            case ProductValue::Observed::SPARSE:
-                break;
+            case ProductValue::Observed::SPARSE: {
+                const size_t size = total_size();
+                const size_t count = observed.sparse_size();
+                if (count == 0) {
+                    observed.set_sparsity(ProductValue::Observed::NONE);
+                } else if (count == size) {
+                    observed.set_sparsity(ProductValue::Observed::ALL);
+                    observed.clear_sparse();
+                } else if (count >= sparse_threshold * size) {
+                    observed.set_sparsity(ProductValue::Observed::DENSE);
+                    for (size_t i = 0; i < size; ++i) {
+                        observed.add_dense(false);
+                    }
+                    for (auto i : observed.sparse()) {
+                        observed.set_dense(i, true);
+                    }
+                    observed.clear_sparse();
+                }
+            } break;
 
             case ProductValue::Observed::NONE:
                 break;
         }
 
         if (LOOM_DEBUG_LEVEL >= 2) {
-            validate(value);
+            validate(observed);
         }
     }
 
-    void normalize_dense (ProductValue & value) const
+    void normalize_dense (ProductValue::Observed & observed) const
     {
-        auto & observed = * value.mutable_observed();
         switch (observed.sparsity()) {
             case ProductValue::Observed::ALL: {
                 observed.set_sparsity(ProductValue::Observed::DENSE);
@@ -279,7 +328,7 @@ struct ValueSchema
         }
 
         if (LOOM_DEBUG_LEVEL >= 2) {
-            validate(value);
+            validate(observed);
         }
     }
 

--- a/src/query_server.hpp
+++ b/src/query_server.hpp
@@ -42,7 +42,6 @@ public:
 
     QueryServer (const CrossCat & cross_cat) :
         cross_cat_(cross_cat),
-        to_sample_(),
         partial_values_(),
         result_factors_(),
         scores_(),
@@ -63,7 +62,6 @@ public:
 private:
 
     const CrossCat & cross_cat_;
-    Value to_sample_;
     std::vector<Value> partial_values_;
     std::vector<std::vector<Value>> result_factors_;
     VectorFloat scores_;
@@ -96,7 +94,6 @@ inline void QueryServer::score_row (
         mixture.score_value(model, value, scores_, rng);
     }
     response.mutable_score()->set_score(distributions::log_sum_exp(scores_));
-
 }
 
 inline void QueryServer::sample_row (
@@ -109,13 +106,11 @@ inline void QueryServer::sample_row (
     response.Clear();
     response.set_id(request.id());
     if (not cross_cat_.schema.is_valid(request.sample().data())) {
-        response.set_error("invalid request data");
+        response.set_error("invalid request.sample.data");
         return;
     }
-    if (request.sample().data().observed().dense_size() !=
-        request.sample().to_sample().dense_size())
-    {
-        response.set_error("observed size != to_sample size");
+    if (not cross_cat_.schema.is_valid(request.sample().to_sample())) {
+        response.set_error("invalid request.sample.to_sample");
         return;
     }
     const size_t sample_count = request.sample().sample_count();
@@ -124,9 +119,10 @@ inline void QueryServer::sample_row (
     }
 
     cross_cat_.value_split(request.sample().data(), partial_values_);
-    * to_sample_.mutable_observed() = request.sample().to_sample();
     result_factors_.resize(sample_count);
-    cross_cat_.value_split_observed(to_sample_, result_factors_.front());
+    cross_cat_.observed_split(
+        request.sample().to_sample(),
+        result_factors_.front());
     std::fill(
         result_factors_.begin() + 1,
         result_factors_.end(),
@@ -134,8 +130,8 @@ inline void QueryServer::sample_row (
 
     const size_t kind_count = cross_cat_.kinds.size();
     for (size_t i = 0; i < kind_count; ++i) {
-        const auto & observed = result_factors_.front()[i].observed();
-        if (cross_cat_.schema.observed_count(observed)) {
+        const auto & to_sample = result_factors_.front()[i].observed();
+        if (cross_cat_.schema.observed_count(to_sample)) {
             const Value & value = partial_values_[i];
             auto & kind = cross_cat_.kinds[i];
             const ProductModel & model = kind.model;

--- a/src/query_server.hpp
+++ b/src/query_server.hpp
@@ -42,7 +42,6 @@ public:
 
     QueryServer (const CrossCat & cross_cat) :
         cross_cat_(cross_cat),
-        value_join_(cross_cat),
         to_sample_(),
         partial_values_(),
         result_factors_(),
@@ -64,7 +63,6 @@ public:
 private:
 
     const CrossCat & cross_cat_;
-    CrossCat::ValueJoiner value_join_;
     Value to_sample_;
     std::vector<Value> partial_values_;
     std::vector<std::vector<Value>> result_factors_;
@@ -114,7 +112,9 @@ inline void QueryServer::sample_row (
         response.set_error("invalid request data");
         return;
     }
-    if (request.sample().data().observed_size() != request.sample().to_sample_size()) {
+    if (request.sample().data().observed().dense_size() !=
+        request.sample().to_sample().dense_size())
+    {
         response.set_error("observed size != to_sample size");
         return;
     }
@@ -152,7 +152,7 @@ inline void QueryServer::sample_row (
 
     for (const auto & result_values : result_factors_) {
         auto & sample = * response.mutable_sample()->add_samples();
-        value_join_(sample, result_values);
+        cross_cat_.value_join(sample, result_values);
     }
 }
 

--- a/src/query_server.hpp
+++ b/src/query_server.hpp
@@ -134,7 +134,8 @@ inline void QueryServer::sample_row (
 
     const size_t kind_count = cross_cat_.kinds.size();
     for (size_t i = 0; i < kind_count; ++i) {
-        if (cross_cat_.schema.observed_count(result_factors_.front()[i])) {
+        const auto & observed = result_factors_.front()[i].observed();
+        if (cross_cat_.schema.observed_count(observed)) {
             const Value & value = partial_values_[i];
             auto & kind = cross_cat_.kinds[i];
             const ProductModel & model = kind.model;

--- a/src/schema.proto
+++ b/src/schema.proto
@@ -77,6 +77,7 @@ message ProductValue {
       ALL = 0;
       DENSE = 1;
       SPARSE = 2;
+      NONE = 4;
     }
     required Sparsity sparsity = 1;
     repeated bool dense = 2;

--- a/src/schema.proto
+++ b/src/schema.proto
@@ -71,22 +71,27 @@ message HyperPrior {
 
 //----------------------------------------------------------------------------
 
-message ProductModel {
-  message Value {
-    message CountList {
-      repeated uint32 items = 1;
+message ProductValue {
+  message Observed {
+    enum Sparsity {
+      ALL = 0;
+      DENSE = 1;
+      SPARSE = 2;
     }
-    message RealList {
-      repeated float items = 1;
-    }
-
-    repeated bool observed = 1;
-    repeated bool booleans = 2;  // including bb
-    repeated uint32 counts = 3;  // including dd, pypd, dpd, gp, bnb
-    repeated float reals = 4;  // including nich
-    repeated CountList count_lists = 5;  // including bps
-    repeated RealList real_lists = 6;  // including niw
+    required Sparsity sparsity = 1;
+    repeated bool dense = 2;
+    repeated uint32 sparse = 3;
   }
+
+  required Observed observed = 1;
+  repeated bool booleans = 2;  // including bb
+  repeated uint32 counts = 3;  // including dd, dpd, gp, bnb
+  repeated float reals = 4;  // including nich
+}
+
+//----------------------------------------------------------------------------
+
+message ProductModel {
 
   message Shared {
     required distributions.Clustering.PitmanYor clustering = 1;
@@ -140,7 +145,7 @@ message CrossCatTree {
 
 message Row {
   required uint64 id = 1;
-  required ProductModel.Value data = 2;
+  required ProductValue data = 2;
 }
 
 //----------------------------------------------------------------------------
@@ -323,13 +328,13 @@ message Query
   {
     message Request
     {
-      required ProductModel.Value data = 1;
-      repeated bool to_sample = 2;
+      required ProductValue data = 1;
+      required ProductValue.Observed to_sample = 2;
       required uint32 sample_count = 3;
     }
     message Response
     {
-      repeated ProductModel.Value samples = 1;
+      repeated ProductValue samples = 1;
     }
   }
 
@@ -337,7 +342,7 @@ message Query
   {
     message Request
     {
-      required ProductModel.Value data = 1;
+      required ProductValue data = 1;
     }
     message Response
     {


### PR DESCRIPTION
This is step 1 of 2 in a 2-step refactoring to allow mostly-constant data, e.g. data that is fully observed but has some frequently occurring value in > 95% of rows.

This pull implements a sparse value data structure with three sparsity types:
- ALL: all values are observed. This only works for fully observed rows.
- DENSE: some values are observed. A bitmask marks which values are observed, and values are stored in packed arrays. This is the current implementation. This best in the density range [0.1, 1)
- SPARSE: very few values are observed. A list of observed ids is stored, and values are stored in packed arrays. This is best in the density range [0, 0.1].

We try in python to deal only with DENSE rows. The query server should start off assuming DENSE rows. The C++ helper `ValueSchema::normalize_dense(row)` and the python class `cFormat.Rows` help to deal with DENSE rows.
