### PR TITLE
Refactor towards multi-sample support

### DIFF
--- a/loom/crossvalidate.py
+++ b/loom/crossvalidate.py
@@ -75,7 +75,7 @@ def crossvalidate(
     mean_scores = []
     for seed in xrange(sample_count):
         LOG('running seed {}:'.format(seed))
-        results = loom.store.get_paths(name, 'crossvalidate', seed)
+        results = loom.store.get_paths(name, 'crossvalidate/{}'.format(seed))
         mkdir_p(results['root'])
         results['train'] = os.path.join(results['root'], 'train.pbs.gz')
         results['test'] = os.path.join(results['root'], 'test.pbs.gz')

--- a/loom/datasets.py
+++ b/loom/datasets.py
@@ -195,11 +195,11 @@ def load(name, schema, rows_csv):
 
 
 @parsable.command
-def clean(name):
+def clean(name, operation=None):
     '''
-    Clean out one datasets.
+    Clean out one dataset.
     '''
-    rm_rf(loom.store.get_paths(name)['root'])
+    rm_rf(loom.store.get_paths(name, operation)['root'])
 
 
 if __name__ == '__main__':

--- a/loom/preql.py
+++ b/loom/preql.py
@@ -1,6 +1,35 @@
-from loom.format import load_encoder, load_decoder
-from distributions.io.stream import open_compressed, json_load
+# Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of Salesforce.com nor the names of its contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import csv
+from distributions.io.stream import open_compressed, json_load
+from loom.format import load_encoder, load_decoder
+import loom.store
+import loom.query
 
 
 class PreQL(object):
@@ -107,3 +136,12 @@ class PreQL(object):
                         joint_entropy)
                     out_row.append(normalized_mi)
                 writer.writerow(out_row)
+
+
+def get_server(root, debug=False, profile=None):
+    '''
+    Gets query server from loom.store.
+    '''
+    encoding = loom.store.get_paths(root)['encoding']
+    query_server = loom.query.get_server(root, debug, profile)
+    return PreQL(query_server, encoding)

--- a/loom/store.py
+++ b/loom/store.py
@@ -35,6 +35,8 @@ else:
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         'data')
 
+MAX_SEED = 999999
+
 DATASET_PATHS = {
     'version': 'version.txt',
     'schema': 'schema.json.gz',
@@ -69,15 +71,29 @@ def get_sample_dirname(dirname, seed):
     return os.path.join(dirname, 'sample.{:06d}'.format(seed))
 
 
-def get_paths(*parts):
-    root = os.path.join(STORE, *map(str, parts))
+def get_paths(name, operation=None, seed=0):
+    assert seed < MAX_SEED, seed
+    root = name if operation is None else os.path.join(name, operation)
+    if not os.path.isabs(root):
+        root = os.path.join(STORE, root)
     paths = {'root': root}
     for name, path in DATASET_PATHS.iteritems():
         paths[name] = os.path.join(root, path)
-    sample_0 = get_sample_dirname(paths['samples'], 0)
+    sample = get_sample_dirname(paths['samples'], int(seed))
     for name, path in SAMPLE_PATHS.iteritems():
-        paths[name] = os.path.join(sample_0, path)
+        paths[name] = os.path.join(sample, path)
     return paths
+
+
+def get_samples(name, operation=None, sample_count=None):
+    if sample_count is None:
+        paths = get_paths(name, operation)
+        sample_count = len(os.listdir(paths['samples']))
+    samples = [
+        get_paths(name, operation, seed=seed)
+        for seed in xrange(int(sample_count))
+    ]
+    return samples
 
 
 ERRORS = {

--- a/loom/test/test_preql.py
+++ b/loom/test/test_preql.py
@@ -1,65 +1,83 @@
-import loom.preql
-import loom.query
-from loom.format import load_encoder
-from test_query import get_protobuf_server
-from distributions.fileutil import tempdir
-from distributions.io.stream import open_compressed, json_load
-from loom.test.util import for_each_dataset, CLEANUP_ON_ERROR
+# Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of Salesforce.com nor the names of its contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import os
 import csv
 from nose.tools import assert_true, assert_almost_equal
+from distributions.fileutil import tempdir
+from distributions.io.stream import open_compressed, json_load
+import loom.preql
+import loom.query
+from loom.format import load_encoder
+from loom.test.util import for_each_dataset, CLEANUP_ON_ERROR
 
 
 @for_each_dataset
-def test_predict(model, groups, rows_csv, encoding, **unused):
+def test_predict(root, rows_csv, encoding, **unused):
     COUNT = 10
     with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
-        protobuf_server = get_protobuf_server(
-            loom.query.MultiSampleProtobufServer,
-            [model, model],
-            [groups, groups])
-        result_out = 'predictions_out.csv'
-        rows_in = os.listdir(rows_csv)[0]
-        rows_in = os.path.join(rows_csv, rows_in)
-        encoders = json_load(encoding)
-        name_to_encoder = {e['name']: load_encoder(e) for e in encoders}
-        query_server = loom.query.QueryServer(protobuf_server)
-        preql = loom.preql.PreQL(query_server, encoding)
-        preql.predict(rows_in, COUNT, result_out, id_offset=False)
-        with open_compressed(rows_in, 'rb') as fin:
-            with open(result_out, 'r') as fout:
-                in_reader = csv.reader(fin)
-                out_reader = csv.reader(fout)
-                fnames = in_reader.next()
-                out_reader.next()
-                for in_row in in_reader:
-                    for i in range(COUNT):
-                        out_row = out_reader.next()
-                        bundle = zip(fnames, in_row, out_row)
-                        for name, in_val, out_val in bundle:
-                            encode = name_to_encoder[name]
-                            observed = bool(in_val.strip())
-                            if observed:
-                                assert_almost_equal(
-                                    encode(in_val),
-                                    encode(out_val))
-                            else:
-                                assert_true(bool(out_val.strip()))
+        with loom.query.get_server(root, debug=True) as query_server:
+            result_out = 'predictions_out.csv'
+            rows_in = os.listdir(rows_csv)[0]
+            rows_in = os.path.join(rows_csv, rows_in)
+            encoders = json_load(encoding)
+            name_to_encoder = {e['name']: load_encoder(e) for e in encoders}
+            preql = loom.preql.PreQL(query_server, encoding)
+            preql.predict(rows_in, COUNT, result_out, id_offset=False)
+            with open_compressed(rows_in, 'rb') as fin:
+                with open(result_out, 'r') as fout:
+                    in_reader = csv.reader(fin)
+                    out_reader = csv.reader(fout)
+                    fnames = in_reader.next()
+                    out_reader.next()
+                    for in_row in in_reader:
+                        for i in range(COUNT):
+                            out_row = out_reader.next()
+                            bundle = zip(fnames, in_row, out_row)
+                            for name, in_val, out_val in bundle:
+                                encode = name_to_encoder[name]
+                                observed = bool(in_val.strip())
+                                if observed:
+                                    assert_almost_equal(
+                                        encode(in_val),
+                                        encode(out_val))
+                                else:
+                                    assert_true(bool(out_val.strip()))
 
 
 @for_each_dataset
-def test_relate(model, groups, encoding, **unused):
+def test_relate(root, encoding, **unused):
     with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
-        protobuf_server = get_protobuf_server(
-            loom.query.MultiSampleProtobufServer,
-            [model, model],
-            [groups, groups])
-        result_out = 'related_out.csv'
-        query_server = loom.query.QueryServer(protobuf_server)
-        preql = loom.preql.PreQL(query_server, encoding)
-        preql.relate(preql.feature_names, result_out, sample_count=10)
-        with open(result_out, 'r') as f:
-            reader = csv.reader(f)
-            for row in reader:
-                pass
-                # print row
+        with loom.query.get_server(root, debug=True) as query_server:
+            result_out = 'related_out.csv'
+            preql = loom.preql.PreQL(query_server, encoding)
+            preql.relate(preql.feature_names, result_out, sample_count=10)
+            with open(result_out, 'r') as f:
+                reader = csv.reader(f)
+                for row in reader:
+                    pass
+                    # print row

--- a/loom/test/test_query.py
+++ b/loom/test/test_query.py
@@ -25,21 +25,16 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
 from itertools import izip
 from nose.tools import assert_true, assert_equal
 from distributions.dbg.random import sample_bernoulli
-from distributions.fileutil import tempdir
 from distributions.io.stream import open_compressed
 from loom.schema_pb2 import ProductValue, CrossCat, Query
-from loom.test.util import for_each_dataset, CLEANUP_ON_ERROR
+from loom.test.util import for_each_dataset
 import loom.query
 from loom.query import SingleSampleProtobufServer, MultiSampleProtobufServer
 from loom.query import protobuf_to_data_row
-from util import load_rows
-
-CONFIG = {}
-
+from loom.test.util import load_rows
 
 NONE = ProductValue.Observed.NONE
 DENSE = ProductValue.Observed.DENSE
@@ -130,11 +125,9 @@ def get_example_requests(model, rows, query_type='mixed'):
     return requests
 
 
-def get_protobuf_server(Server, model, groups):
-    config_in = os.path.abspath('config.pb.gz')
-    loom.config.config_dump(CONFIG, config_in)
+def get_protobuf_server(Server, config, model, groups):
     kwargs = {
-        'config_in': config_in,
+        'config_in': config,
         'model_in': model,
         'groups_in': groups,
         'debug': True,
@@ -170,32 +163,28 @@ def _test_server(Server, requests, args):
 
 
 @for_each_dataset
-def test_sample_one(model, groups, rows, **unused):
+def test_sample_one(config, model, groups, rows, **unused):
     requests = get_example_requests(model, rows, 'sample')
-    with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
-        args = [model, groups]
-        _test_server(SingleSampleProtobufServer, requests, args)
+    args = [config, model, groups]
+    _test_server(SingleSampleProtobufServer, requests, args)
 
 
 @for_each_dataset
-def test_sample_multi(model, groups, rows, **unused):
+def test_sample_multi(config, model, groups, rows, **unused):
     requests = get_example_requests(model, rows, 'sample')
-    with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
-        args = [[model, model], [groups, groups]]
-        _test_server(MultiSampleProtobufServer, requests, args)
+    args = [config, [model, model], [groups, groups]]
+    _test_server(MultiSampleProtobufServer, requests, args)
 
 
 @for_each_dataset
-def test_score_one(model, groups, rows, **unused):
+def test_score_one(config, model, groups, rows, **unused):
     requests = get_example_requests(model, rows, 'score')
-    with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
-        args = [model, groups]
-        _test_server(SingleSampleProtobufServer, requests, args)
+    args = [config, model, groups]
+    _test_server(SingleSampleProtobufServer, requests, args)
 
 
 @for_each_dataset
-def test_score_multi(model, groups, rows, **unused):
+def test_score_multi(config, model, groups, rows, **unused):
     requests = get_example_requests(model, rows, 'score')
-    with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
-        args = [[model, model], [groups, groups]]
-        _test_server(MultiSampleProtobufServer, requests, args)
+    args = [config, [model, model], [groups, groups]]
+    _test_server(MultiSampleProtobufServer, requests, args)


### PR DESCRIPTION
@jglidden This also cleans up some of the query tests, in particular using context managers when starting servers. What do you think of the `loom.query.get_server` helper? I'd like to eventually start servers with `root` variables.
