### PR TITLE
Move multi-sample logic to C++ 

### DIFF
--- a/loom/crossvalidate.py
+++ b/loom/crossvalidate.py
@@ -121,8 +121,7 @@ def crossvalidate(
             debug=debug)
         LOG(' query')
         rows = loom.query.load_data_rows(results['test'])
-        samples = results['samples'][:1]
-        with loom.query.get_server(samples, debug=debug) as query:
+        with loom.query.get_server(results['root'], debug=debug) as query:
             scores = [query.score(row) for row in rows]
 
         json_dump(scores, results['scores'])

--- a/loom/datasets.py
+++ b/loom/datasets.py
@@ -157,6 +157,7 @@ def generate_one((name, sample_count, force, debug)):
         rows_in=paths['ingest']['rows'],
         rows_csv_out=paths['ingest']['rows_csv'],
         chunk_size=chunk_size)
+    protobuf_stream_dump([], paths['query']['query_log'])
     for seed, sample in enumerate(paths['samples']):
         loom.config.config_dump({'seed': seed}, sample['config'])
         loom.generate.generate_init(
@@ -169,7 +170,6 @@ def generate_one((name, sample_count, force, debug)):
             seed=seed,
             debug=debug)
         protobuf_stream_dump([], sample['infer_log'])
-        protobuf_stream_dump([], sample['query_log'])
     sample0 = paths['samples'][0]
     for seed, sample in enumerate(paths['samples'][1:]):
         loom.runner.mix(

--- a/loom/preql.py
+++ b/loom/preql.py
@@ -144,7 +144,6 @@ class PreQL(object):
         'samples.0.config',
         'samples.0.model',
         'samples.0.groups'])
-def get_server(samples, encoding, debug=False, profile=None):
-    assert isinstance(samples, list), samples
-    query_server = loom.query.get_server(samples, debug, profile)
+def get_server(root, encoding, debug=False, profile=None):
+    query_server = loom.query.get_server(root, debug, profile)
     return PreQL(query_server, encoding)

--- a/loom/query.py
+++ b/loom/query.py
@@ -30,9 +30,6 @@ from itertools import izip, chain
 from collections import namedtuple
 import numpy
 from distributions.io.stream import protobuf_stream_write, protobuf_stream_read
-from distributions.lp.random import log_sum_exp
-from distributions.dbg.random import sample_discrete
-from distributions.util import scores_to_probs
 from loom.schema_pb2 import Query, ProductValue
 import loom.cFormat
 import loom.runner
@@ -242,90 +239,11 @@ class QueryServer(object):
         return get_estimate(mis)
 
 
-class MultiSampleProtobufServer(object):
-    def __init__(self, samples, debug=False, profile=None):
-        self.servers = [
-            SingleSampleProtobufServer(sample, debug, profile)
-            for sample in samples
-        ]
-
-    def send(self, request):
-        requests = []
-        for server in self.servers:
-            req = Query.Request()
-            req.CopyFrom(request)
-            requests.append(req)
-        if request.HasField("sample"):
-            score_request = Query.Request()
-            score_request.id = 'score_conditions'
-            data_row = protobuf_to_data_row(request.sample.data)
-            to_sample = request.sample.to_sample.dense
-            conditioning_row = [val if not ts else None
-                                for val, ts in zip(data_row, to_sample)]
-            data_row_to_protobuf(conditioning_row, score_request.score.data)
-            for server in self.servers:
-                server.send(score_request)
-            scores = [s.receive().score.score for s in self.servers]
-            probs = numpy.array(scores_to_probs(scores))
-            per_server_counts = [0 for server in self.servers]
-            total_count = request.sample.sample_count
-            for _ in range(total_count):
-                i = sample_discrete(probs)
-                per_server_counts[i] += 1
-            # TODO handle 0 counts?
-            for req, count in izip(requests, per_server_counts):
-                req.sample.sample_count = count
-        if request.HasField("score"):
-            # score requests passed to each sample
-            pass
-        for req, server in izip(requests, self.servers):
-            server.send(req)
-
-    def receive(self):
-        responses = [server.receive() for server in self.servers]
-        assert len(set([res.id for res in responses])) == 1
-
-        samples = [res.sample.samples for res in responses]
-        samples = list(chain(*samples))
-        numpy.random.shuffle(samples)
-        # FIXME what if request did not have score
-        score_part = log_sum_exp([res.score.score for res in responses])
-        score = score_part - numpy.log(len(responses))
-
-        response = Query.Response()
-        response.id = responses[0].id  # HACK
-        for res in responses:
-            response.error.extend(res.error)
-        response.sample.samples.extend(samples)
-        response.score.score = score
-        return response
-
-    def call(self, request):
-        response = Query.Response()
-        if request.HasField("sample"):
-            self.__sample(request, response)
-        if request.HasField("score"):
-            self.__score(request, response)
-        return response
-
-    def close(self):
-        for server in self.servers:
-            server.close()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *unused):
-        self.close()
-
-
-class SingleSampleProtobufServer(object):
-    def __init__(self, paths, debug=False, profile=None):
+class ProtobufServer(object):
+    def __init__(self, root, debug=False, profile=None):
         self.proc = loom.runner.query(
-            config_in=paths['config'],
-            model_in=paths['model'],
-            groups_in=paths['groups'],
-            log_out=paths['query_log'],
+            root_in=root,
+            log_out=None,
             debug=debug,
             profile=profile,
             block=False)
@@ -355,7 +273,6 @@ class SingleSampleProtobufServer(object):
         self.close()
 
 
-def get_server(samples, debug=False, profile=None):
-    assert isinstance(samples, list), samples
-    protobuf_server = MultiSampleProtobufServer(samples, debug, profile)
+def get_server(root, debug=False, profile=None):
+    protobuf_server = ProtobufServer(root, debug, profile)
     return QueryServer(protobuf_server)

--- a/loom/runner.py
+++ b/loom/runner.py
@@ -344,9 +344,7 @@ def posterior_enum(
     inputs=['samples.0.config', 'samples.0.model', 'samples.0.groups'])
 @parsable.command
 def query(
-        config_in,
-        model_in,
-        groups_in,
+        root_in,
         requests_in='-',
         responses_out='-',
         log_out=None,
@@ -357,12 +355,8 @@ def query(
     Run query server from a trained model.
     '''
     log_out = optional_file(log_out)
-    command = [
-        'query',
-        config_in, model_in, groups_in, requests_in,
-        responses_out, log_out,
-    ]
-    infiles = [config_in, model_in, groups_in, requests_in]
+    command = ['query', root_in, requests_in, responses_out, log_out]
+    infiles = [root_in, requests_in]
     if block:
         check_call_files(
             command=command,

--- a/loom/store.py
+++ b/loom/store.py
@@ -68,12 +68,20 @@ CONSENSUS_PATHS = {
 }
 
 
-def get_mixture_filename(dirname, kindid):
+def get_mixture_path(groups_path, kindid):
     '''
-    This must match get_mixture_filename(-,-) in src/cross_cat.cc
+    This must match loom::store::get_mixture_path(-,-) in src/store.hpp
     '''
     assert kindid < MAX_KIND_COUNT, kindid
-    return os.path.join(dirname, 'mixture.{:06d}.pbs.gz'.format(kindid))
+    return os.path.join(groups_path, 'mixture.{:d}.pbs.gz'.format(kindid))
+
+
+def get_sample_path(root, seed):
+    '''
+    This must match loom::store::get_sample_path(-,-) in src/store.hpp
+    '''
+    assert seed >= 0
+    return os.path.join(root, 'samples', 'sample.{:d}'.format(seed))
 
 
 def join_paths(*args):
@@ -92,10 +100,7 @@ def get_paths(root, sample_count=1):
     paths['ingest'] = join_paths(root, 'ingest', INGEST_PATHS)
     paths['samples'] = []
     for seed in xrange(sample_count):
-        sample_root = os.path.join(
-            root,
-            'samples',
-            'sample.{:06d}'.format(seed))
+        sample_root = get_sample_path(root, seed)
         paths['samples'].append(join_paths(sample_root, SAMPLE_PATHS))
     paths['consensus'] = join_paths(root, 'consensus', CONSENSUS_PATHS)
     return paths

--- a/loom/test/test_preql.py
+++ b/loom/test/test_preql.py
@@ -37,10 +37,10 @@ from loom.test.util import for_each_dataset, CLEANUP_ON_ERROR
 
 
 @for_each_dataset
-def test_predict(rows_csv, encoding, samples, **unused):
+def test_predict(root, rows_csv, encoding, **unused):
     COUNT = 10
     with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
-        with loom.query.get_server(samples, debug=True) as query_server:
+        with loom.query.get_server(root, debug=True) as query_server:
             result_out = 'predictions_out.csv'
             rows_in = os.listdir(rows_csv)[0]
             rows_in = os.path.join(rows_csv, rows_in)
@@ -70,8 +70,8 @@ def test_predict(rows_csv, encoding, samples, **unused):
 
 
 @for_each_dataset
-def test_relate(samples, encoding, **unused):
-    with loom.query.get_server(samples, debug=True) as query_server:
+def test_relate(root, encoding, **unused):
+    with loom.query.get_server(root, debug=True) as query_server:
         with tempdir(cleanup_on_error=CLEANUP_ON_ERROR):
             result_out = 'related_out.csv'
             preql = loom.preql.PreQL(query_server, encoding)

--- a/loom/test/test_query_math.py
+++ b/loom/test/test_query_math.py
@@ -40,10 +40,6 @@ from distributions.util import (
 )
 import loom.preql
 import loom.query
-from loom.query import (
-    SingleSampleProtobufServer,
-    MultiSampleProtobufServer
-)
 from loom.test.util import for_each_dataset, load_rows
 
 
@@ -59,29 +55,21 @@ MIN_CATEGORICAL_PROB = .03
 
 
 @for_each_dataset
-def test_score_none(samples, encoding, **unused):
-    cases = [
-        (SingleSampleProtobufServer, samples[0]),
-        (MultiSampleProtobufServer, samples[:1]),
-        (MultiSampleProtobufServer, samples),
-        (MultiSampleProtobufServer, [samples[0], samples[0]]),
-    ]
-    for Server, samples in cases:
-        with Server(samples, debug=True) as protobuf_server:
-            query_server = loom.query.QueryServer(protobuf_server)
-            preql = loom.preql.PreQL(query_server, encoding)
-            fnames = preql.feature_names
-            assert_almost_equal(
-                query_server.score([None for _ in fnames]),
-                0.,
-                places=GOF_EXP)
+def test_score_none(root, encoding, **unused):
+    with loom.query.get_server(root, debug=True) as server:
+        preql = loom.preql.PreQL(server, encoding)
+        fnames = preql.feature_names
+        assert_almost_equal(
+            server.score([None for _ in fnames]),
+            0.,
+            places=GOF_EXP)
 
 
 @for_each_dataset
-def test_mi_entropy_relations(samples, encoding, **unused):
+def test_mi_entropy_relations(root, encoding, **unused):
     raise SkipTest('FIXME(jglidden) test fails too often')
-    with loom.query.get_server(samples, debug=True) as query_server:
-        preql = loom.preql.PreQL(query_server, encoding)
+    with loom.query.get_server(root, debug=True) as server:
+        preql = loom.preql.PreQL(server, encoding)
         fnames = preql.feature_names
         feature_sets = [
             [fnames[0]],
@@ -92,17 +80,17 @@ def test_mi_entropy_relations(samples, encoding, **unused):
             to_sample1 = preql.cols_to_sample(fset1)
             to_sample2 = preql.cols_to_sample(fset2)
             to_sample = preql.cols_to_sample(fset1 + fset2)
-            mutual_info = query_server.mutual_information(
+            mutual_info = server.mutual_information(
                 to_sample1,
                 to_sample2,
                 sample_count=SAMPLE_COUNT)
-            entropy1 = query_server.entropy(
+            entropy1 = server.entropy(
                 to_sample1,
                 sample_count=SAMPLE_COUNT)
-            entropy2 = query_server.entropy(
+            entropy2 = server.entropy(
                 to_sample2,
                 sample_count=SAMPLE_COUNT)
-            entropy_joint = query_server.entropy(
+            entropy_joint = server.entropy(
                 to_sample,
                 sample_count=SAMPLE_COUNT)
             if to_sample1 == to_sample2:
@@ -119,21 +107,20 @@ def test_mi_entropy_relations(samples, encoding, **unused):
             assert_less_equal(abs(actual - expected), Z_SCORE * error)
 
 
-def _check_marginal_samples_match_scores(protobuf_server, row, fi):
-    query_server = loom.query.QueryServer(protobuf_server)
+def _check_marginal_samples_match_scores(server, row, fi):
     row = loom.query.protobuf_to_data_row(row.diff)
     row[fi] = None
     to_sample = [i == fi for i in range(len(row))]
-    samples = query_server.sample(to_sample, row, SAMPLE_COUNT)
+    samples = server.sample(to_sample, row, SAMPLE_COUNT)
     val = samples[0][fi]
-    base_score = query_server.score(row)
+    base_score = server.score(row)
     if isinstance(val, bool) or isinstance(val, int):
         probs_dict = {}
         samples = [sample[fi] for sample in samples]
         for sample in set(samples):
             row[fi] = sample
             probs_dict[sample] = numpy.exp(
-                query_server.score(row) - base_score)
+                server.score(row) - base_score)
         if len(probs_dict) == 1:
             assert_almost_equal(probs_dict[sample], 1., places=GOF_EXP)
             return
@@ -142,7 +129,7 @@ def _check_marginal_samples_match_scores(protobuf_server, row, fi):
         gof = discrete_goodness_of_fit(samples, probs_dict, plot=True)
     elif isinstance(val, float):
         probs = numpy.exp([
-            query_server.score(sample) - base_score
+            server.score(sample) - base_score
             for sample in samples
         ])
         samples = [sample[fi] for sample in samples]
@@ -151,21 +138,9 @@ def _check_marginal_samples_match_scores(protobuf_server, row, fi):
 
 
 @for_each_dataset
-def test_samples_match_scores_one(samples, rows, **unused):
-    raise SkipTest('FIXME(jglidden) test fails too often')
-    Server = SingleSampleProtobufServer
+def test_samples_match_scores(root, rows, **unused):
     rows = load_rows(rows)
     rows = rows[::len(rows) / 2]
-    with Server(samples[0], debug=True) as protobuf_server:
+    with loom.query.get_server(root, debug=True) as server:
         for row in rows:
-            _check_marginal_samples_match_scores(protobuf_server, row, 0)
-
-
-@for_each_dataset
-def test_samples_match_scores_multi(samples, rows, **unused):
-    Server = MultiSampleProtobufServer
-    rows = load_rows(rows)
-    rows = rows[::len(rows) / 2]
-    with Server(samples, debug=True) as protobuf_server:
-        for row in rows:
-            _check_marginal_samples_match_scores(protobuf_server, row, 0)
+            _check_marginal_samples_match_scores(server, row, 0)

--- a/loom/test/test_tasks.py
+++ b/loom/test/test_tasks.py
@@ -55,8 +55,7 @@ def test_all(name, schema, rows_csv, **unused):
     requests = get_example_requests(
         paths['samples'][0]['model'],
         paths['ingest']['rows'])
-    Server = loom.query.MultiSampleProtobufServer
-    with Server(paths['samples'], debug=True) as server:
+    with loom.query.ProtobufServer(paths['root'], debug=True) as server:
         for request in requests:
             server.send(request)
             response = server.receive()

--- a/loom/test/util.py
+++ b/loom/test/util.py
@@ -52,6 +52,7 @@ def for_each_dataset(fun):
                     'missing {} at {},\n  first `python -m loom.datasets test`'
                     .format(key, path))
         kwargs = {'name': dataset}
+        kwargs.update(paths['query'])
         kwargs.update(paths['consensus'])
         kwargs.update(paths['samples'][0])
         kwargs.update(paths['ingest'])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set_source_files_properties(schema.pb.cc
 
 add_library(loom
   loom.cc
+  multi_loom.cc
   logger.cc
   product_value.cc
   product_model.cc
@@ -29,6 +30,7 @@ add_library(loom
   kind_kernel.cc
   kind_proposer.cc
   kind_pipeline.cc
+  query_server.cc
   differ.cc
   schema.pb.cc
   ${DISTRIBUTIONS_INCLUDE_DIR}/distributions/io/schema.pb.cc

--- a/src/cross_cat.cc
+++ b/src/cross_cat.cc
@@ -29,6 +29,7 @@
 #include <iomanip>
 #include <distributions/io/protobuf.hpp>
 #include <loom/protobuf_stream.hpp>
+#include <loom/store.hpp>
 #include <loom/cross_cat.hpp>
 #include <loom/infer_grid.hpp>
 
@@ -144,17 +145,6 @@ void CrossCat::tares_load (const char * filename, rng_t & rng)
     update_tares(temp_values, rng);
 }
 
-std::string CrossCat::get_mixture_filename (
-        const char * dirname,
-        size_t kindid) const
-{
-    LOOM_ASSERT_LE(kindid, kinds.size());
-    std::ostringstream filename;
-    filename << dirname << "/mixture." <<
-        std::setfill('0') << std::setw(6) << kindid << ".pbs.gz";
-    return filename.str();
-}
-
 void CrossCat::mixture_load (
         const char * dirname,
         size_t empty_group_count,
@@ -168,7 +158,7 @@ void CrossCat::mixture_load (
     for (size_t kindid = 0; kindid < kind_count; ++kindid) {
         rng_t rng(seed + kindid);
         Kind & kind = kinds[kindid];
-        std::string filename = get_mixture_filename(dirname, kindid);
+        std::string filename = store::get_mixture_path(dirname, kindid);
         kind.mixture.maintaining_cache = true;
         kind.mixture.load_step_1_of_3(
             kind.model,
@@ -214,7 +204,7 @@ void CrossCat::mixture_dump (
     for (size_t kindid = 0; kindid < kind_count; ++kindid) {
         const Kind & kind = kinds[kindid];
         const auto & sorted_to_global = sorted_to_globals[kindid];
-        std::string filename = get_mixture_filename(dirname, kindid);
+        std::string filename = store::get_mixture_path(dirname, kindid);
         kind.mixture.dump(filename.c_str(), sorted_to_global);
     }
 }

--- a/src/cross_cat.hpp
+++ b/src/cross_cat.hpp
@@ -83,12 +83,6 @@ struct CrossCat : noncopyable
     float score_data (rng_t & rng) const;
 
     void validate () const;
-
-private:
-
-    std::string get_mixture_filename (
-            const char * dirname,
-            size_t kindid) const;
 };
 
 inline void CrossCat::simplify (

--- a/src/loom.cc
+++ b/src/loom.cc
@@ -31,7 +31,6 @@
 #include <loom/hyper_kernel.hpp>
 #include <loom/kind_kernel.hpp>
 #include <loom/kind_pipeline.hpp>
-#include <loom/query_server.hpp>
 #include <loom/stream_interval.hpp>
 #include <loom/generate.hpp>
 
@@ -586,27 +585,4 @@ void Loom::mix (
     }
 }
 
-void Loom::query (
-        rng_t & rng,
-        const char * requests_in,
-        const char * responses_out)
-{
-    protobuf::InFile query_stream(requests_in);
-    protobuf::OutFile response_stream(responses_out);
-    protobuf::Query::Request request;
-    protobuf::Query::Response response;
-
-    QueryServer server(cross_cat_);
-
-    while (query_stream.try_read_stream(request)) {
-        if (request.has_sample()) {
-            server.sample_row(rng, request, response);
-        }
-        if (request.has_score()) {
-            server.score_row(rng, request, response);
-        }
-        response_stream.write_stream(response);
-        response_stream.flush();
-    }
-}
 } // namespace loom

--- a/src/loom.hpp
+++ b/src/loom.hpp
@@ -27,8 +27,6 @@
 
 #pragma once
 
-#include <thread>
-#include <vector>
 #include <unordered_map>
 #include <loom/common.hpp>
 #include <loom/cross_cat.hpp>
@@ -85,10 +83,7 @@ public:
             rng_t & rng,
             const char * rows_in);
 
-    void query (
-            rng_t & rng,
-            const char * requests_in,
-            const char * responses_out);
+    const CrossCat & cross_cat () const { return cross_cat_; }
 
 private:
 

--- a/src/multi_loom.cc
+++ b/src/multi_loom.cc
@@ -25,7 +25,7 @@
 // TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <unistd.h>
+#include <fstream>
 #include <loom/store.hpp>
 #include <loom/multi_loom.hpp>
 
@@ -62,7 +62,10 @@ MultiLoom::MultiLoom (
         bool load_tares)
 {
     const auto paths = store::get_paths(root_in);
-    const char * tares_in = load_tares ? paths.ingest.tares.c_str() : nullptr;
+    const char * tares_in = paths.ingest.tares.c_str();
+    if (not (load_tares and std::ifstream(tares_in))) {
+        tares_in = nullptr;
+    }
     for (const auto & sample_paths : paths.samples) {
         samples_.push_back(
             new Sample(sample_paths, load_groups, load_assign, tares_in));
@@ -77,7 +80,7 @@ MultiLoom::~MultiLoom ()
     }
 }
 
-std::vector<const CrossCat *> MultiLoom::cross_cats () const
+const std::vector<const CrossCat *> MultiLoom::cross_cats () const
 {
     std::vector<const CrossCat *> result;
     for (const auto * sample : samples_) {

--- a/src/multi_loom.hpp
+++ b/src/multi_loom.hpp
@@ -27,48 +27,29 @@
 
 #pragma once
 
-#include <loom/timer.hpp>
-#include <loom/cross_cat.hpp>
+#include <loom/loom.hpp>
 
 namespace loom
 {
 
-class QueryServer
+class MultiLoom : noncopyable
 {
 public:
 
-    typedef protobuf::Query::Request Request;
-    typedef protobuf::Query::Response Response;
+    MultiLoom (
+            const char * root_in,
+            bool load_groups = false,
+            bool load_assign = false,
+            bool load_tares = false);
+    ~MultiLoom ();
 
-    QueryServer (const CrossCat & cross_cat) :
-        cross_cat_(cross_cat)
-    {
-    }
-
-    void serve (
-            rng_t & rng,
-            const char * requests_in,
-            const char * responses_out);
+    std::vector<const CrossCat *> cross_cats () const;
 
 private:
 
-    void score_row (
-            rng_t & rng,
-            const Request & request,
-            Response & response);
+    struct Sample;
 
-    void sample_row (
-            rng_t & rng,
-            const Request & request,
-            Response & response);
-
-    const CrossCat & cross_cat_;
-    ProductValue::Diff temp_diff_;
-    std::vector<ProductValue::Diff> partial_diffs_;
-    std::vector<std::vector<ProductValue::Diff>> result_factors_;
-    std::vector<ProductValue *> temp_values_;
-    VectorFloat scores_;
-    Timer timer_;
+    std::vector<Sample *> samples_;
 };
 
 } // namespace loom

--- a/src/multi_loom.hpp
+++ b/src/multi_loom.hpp
@@ -43,7 +43,7 @@ public:
             bool load_tares = false);
     ~MultiLoom ();
 
-    std::vector<const CrossCat *> cross_cats () const;
+    const std::vector<const CrossCat *> cross_cats () const;
 
 private:
 

--- a/src/query.cc
+++ b/src/query.cc
@@ -29,6 +29,8 @@
 #include <loom/protobuf_stream.hpp>
 #include <loom/logger.hpp>
 #include <loom/loom.hpp>
+#include <loom/multi_loom.hpp>
+#include <loom/query_server.hpp>
 
 const char * help_message =
 "Usage: query CONFIG_IN MODEL_IN GROUPS_IN REQUESTS_IN RESPONSES_OUT LOG_OUT"
@@ -65,8 +67,9 @@ int main (int argc, char ** argv)
     const auto config = loom::protobuf_load<loom::protobuf::Config>(config_in);
     loom::rng_t rng(config.seed());
     loom::Loom engine(rng, config, model_in, groups_in);
+    loom::QueryServer server(engine.cross_cat());
 
-    engine.query(rng, requests_in, responses_out);
+    server.serve(rng, requests_in, responses_out);
 
     return 0;
 }

--- a/src/query.cc
+++ b/src/query.cc
@@ -28,16 +28,13 @@
 #include <loom/args.hpp>
 #include <loom/protobuf_stream.hpp>
 #include <loom/logger.hpp>
-#include <loom/loom.hpp>
 #include <loom/multi_loom.hpp>
 #include <loom/query_server.hpp>
 
 const char * help_message =
-"Usage: query CONFIG_IN MODEL_IN GROUPS_IN REQUESTS_IN RESPONSES_OUT LOG_OUT"
+"Usage: query ROOT_IN REQUESTS_IN RESPONSES_OUT LOG_OUT"
 "\nArguments:"
-"\n  CONFIG_IN       filename of config (e.g. config.pb.gz)"
-"\n  MODEL_IN        filename of model (e.g. model.pb.gz)"
-"\n  GROUPS_IN       dirname containing per-kind group files"
+"\n  ROOT_IN         root dirname of dataset in loom store"
 "\n  REQUESTS_IN     filename of requests stream (e.g. requests.pbs.gz)"
 "\n  RESPONSES_OUT   filename of responses stream (e.g. responses.pbs.gz)"
 "\n  LOG_OUT         filename of log (e.g. log.pbs.gz)"
@@ -52,9 +49,7 @@ int main (int argc, char ** argv)
     GOOGLE_PROTOBUF_VERIFY_VERSION;
 
     Args args(argc, argv, help_message);
-    const char * config_in = args.pop();
-    const char * model_in = args.pop();
-    const char * groups_in = args.pop();
+    const char * root_in = args.pop();
     const char * requests_in = args.pop();
     const char * responses_out = args.pop();
     const char * log_out = args.pop_optional_file();
@@ -64,10 +59,12 @@ int main (int argc, char ** argv)
         loom::logger.append(log_out);
     }
 
-    const auto config = loom::protobuf_load<loom::protobuf::Config>(config_in);
-    loom::rng_t rng(config.seed());
-    loom::Loom engine(rng, config, model_in, groups_in);
-    loom::QueryServer server(engine.cross_cat());
+    const bool load_groups = true;
+    const bool load_assign = false;
+    const bool load_tares = true;
+    loom::MultiLoom engine(root_in, load_groups, load_assign, load_tares);
+    loom::QueryServer server(engine.cross_cats());
+    loom::rng_t rng;
 
     server.serve(rng, requests_in, responses_out);
 

--- a/src/query_server.cc
+++ b/src/query_server.cc
@@ -1,0 +1,168 @@
+// Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// - Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+// - Neither the name of Salesforce.com nor the names of its contributors
+//   may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+// TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <loom/query_server.hpp>
+
+namespace loom
+{
+
+void QueryServer::serve (
+        rng_t & rng,
+        const char * requests_in,
+        const char * responses_out)
+{
+    protobuf::InFile query_stream(requests_in);
+    protobuf::OutFile response_stream(responses_out);
+    protobuf::Query::Request request;
+    protobuf::Query::Response response;
+
+    while (query_stream.try_read_stream(request)) {
+        if (request.has_sample()) {
+            sample_row(rng, request, response);
+        }
+        if (request.has_score()) {
+            score_row(rng, request, response);
+        }
+        response_stream.write_stream(response);
+        response_stream.flush();
+    }
+}
+
+void QueryServer::score_row (
+        rng_t & rng,
+        const Request & request,
+        Response & response)
+{
+    Timer::Scope timer(timer_);
+
+    response.Clear();
+    response.set_id(request.id());
+    if (not cross_cat_.schema.is_valid(request.score().data())) {
+        response.add_error("invalid query data");
+        return;
+    }
+
+    cross_cat_.splitter.split(
+        request.score().data(),
+        partial_diffs_,
+        temp_values_);
+
+    const size_t kind_count = cross_cat_.kinds.size();
+    float score = 0.f;
+    for (size_t i = 0; i < kind_count; ++i) {
+        const ProductValue::Diff & diff = partial_diffs_[i];
+        auto & kind = cross_cat_.kinds[i];
+        const ProductModel & model = kind.model;
+        auto & mixture = kind.mixture;
+
+        if (diff.tares_size()) {
+            mixture.score_diff(model, diff, scores_, rng);
+        } else {
+            mixture.score_value(model, diff.pos(), scores_, rng);
+        }
+        score += distributions::log_sum_exp(scores_);
+    }
+    response.mutable_score()->set_score(score);
+}
+
+void QueryServer::sample_row (
+        rng_t & rng,
+        const Request & request,
+        Response & response)
+{
+    Timer::Scope timer(timer_);
+
+    response.Clear();
+    response.set_id(request.id());
+    if (not cross_cat_.schema.is_valid(request.sample().data())) {
+        response.add_error("invalid request.sample.data");
+        return;
+    }
+    for (auto id : request.sample().data().tares()) {
+        if (id >= cross_cat_.tares.size()) {
+            response.add_error("invalid request.sample.data.tares");
+        }
+    }
+    if (not cross_cat_.schema.is_valid(request.sample().to_sample())) {
+        response.add_error("invalid request.sample.to_sample");
+        return;
+    }
+
+    const size_t sample_count = request.sample().sample_count();
+    if (sample_count == 0) {
+        return;
+    }
+
+    cross_cat_.schema.clear(temp_diff_);
+    * temp_diff_.mutable_pos()->mutable_observed() =
+        request.sample().to_sample();
+    cross_cat_.schema.fill_data_with_zeros(* temp_diff_.mutable_pos());
+    result_factors_.resize(sample_count);
+    cross_cat_.splitter.split(
+        temp_diff_,
+        result_factors_.front(),
+        temp_values_);
+    std::fill(
+        result_factors_.begin() + 1,
+        result_factors_.end(),
+        result_factors_.front());
+
+    cross_cat_.splitter.split(
+        request.sample().data(),
+        partial_diffs_,
+        temp_values_);
+    const size_t kind_count = cross_cat_.kinds.size();
+    for (size_t i = 0; i < kind_count; ++i) {
+        const auto & to_sample = result_factors_.front()[i].pos().observed();
+        if (cross_cat_.schema.observed_count(to_sample)) {
+            const ProductValue::Diff & diff = partial_diffs_[i];
+            auto & kind = cross_cat_.kinds[i];
+            const ProductModel & model = kind.model;
+            auto & mixture = kind.mixture;
+
+            if (diff.tares_size()) {
+                mixture.score_diff(model, diff, scores_, rng);
+            } else {
+                mixture.score_value(model, diff.pos(), scores_, rng);
+            }
+            distributions::scores_to_probs(scores_);
+            const VectorFloat & probs = scores_;
+
+            for (auto & result_values : result_factors_) {
+                ProductValue & value = * result_values[i].mutable_pos();
+                mixture.sample_value(model, probs, value, rng);
+            }
+        }
+    }
+
+    for (const auto & result_values : result_factors_) {
+        auto & sample = * response.mutable_sample()->add_samples();
+        cross_cat_.splitter.join(sample, result_values);
+    }
+}
+
+} // namespace loom

--- a/src/query_server.hpp
+++ b/src/query_server.hpp
@@ -40,9 +40,10 @@ public:
     typedef protobuf::Query::Request Request;
     typedef protobuf::Query::Response Response;
 
-    QueryServer (const CrossCat & cross_cat) :
-        cross_cat_(cross_cat)
+    QueryServer (const std::vector<const CrossCat *> & cross_cats) :
+        cross_cats_(cross_cats)
     {
+        LOOM_ASSERT(not cross_cats_.empty(), "no cross cats found");
     }
 
     void serve (
@@ -52,17 +53,23 @@ public:
 
 private:
 
+    const ValueSchema schema () const { return cross_cats_[0]->schema; }
+    const std::vector<ProductValue> tares () const
+    {
+        return cross_cats_[0]->tares;
+    }
+
     void score_row (
             rng_t & rng,
             const Request & request,
             Response & response);
 
-    void sample_row (
+    void sample_rows (
             rng_t & rng,
             const Request & request,
             Response & response);
 
-    const CrossCat & cross_cat_;
+    const std::vector<const CrossCat *> cross_cats_;
     ProductValue::Diff temp_diff_;
     std::vector<ProductValue::Diff> partial_diffs_;
     std::vector<std::vector<ProductValue::Diff>> result_factors_;

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <sys/time.h>
+#include <loom/common.hpp>
 
 namespace loom
 {


### PR DESCRIPTION
The C++ implementation is ugly and slow, but should be correct.

This moves multi-sample logic from `loom.query.MultiSampleProtobufServer` to `loom::QueryServer` in `src/query_server.cc` https://github.com/priorknowledge/loom/pull/46/files#diff-3e16722759b678b24dabd87bbc910c79R1
