### PR TITLE
Clean up QueryServer::call(...ScoreDerivative...)

### DIFF
--- a/src/query_server.hpp
+++ b/src/query_server.hpp
@@ -100,6 +100,9 @@ private:
             const Query::ScoreDerivative::Request & request,
             Query::ScoreDerivative::Response & response) const;
 
+    class Scorer;
+    class AssignmentHypothesis;
+
     const protobuf::Config config_;
     const std::vector<const CrossCat *> cross_cats_;
     const char * rows_in_;


### PR DESCRIPTION
@jglidden I just factored out a couple helper classes: `QuerServer::Scorer` and `QueryServer::AssignmentHypothesis`. The `AssignmentHypothesis` uses RAII [1] analogously to python context managers. There was one error in a counter, a stray `i++`.

[1] http://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization
