### PR TITLE
Add transforms support in preql

### DIFF
--- a/doc/using.md
+++ b/doc/using.md
@@ -46,29 +46,29 @@ all relevant columns in `rows.csv`.
 
 An example `schema.csv`:
 
-| Feature Name | Type                   |
-|--------------|------------------------|
-| full name    | id                     |
-| start date   | optional\_date         |
-| age          | real                   |
-| zipcode      | unbounded\_categorical |
-| description  | text                   |
-| misc unused  |                        |
+| Feature Name | Type
+|--------------|-----------------------
+| full name    | id
+| start date   | optional\_date
+| age          | real
+| zipcode      | unbounded\_categorical
+| description  | text
+| misc unused  |
 
 Loom currently supports the following fluent feature types in `loom.tasks.transform`:
 
-| Fluent Type            | Example Values                                 | Transforms To        |
-|------------------------|------------------------------------------------|----------------------|
-| boolean                | '0', '1', 'true', 'false'                      | bb                   |
-| categorical            | 'Monday', 'June'                               | dd                   |
-| unbounded\_categorical | 'CRM', '90210'                                 | dpd                  |
-| count                  | '0', '1', '2', '3', '4'                        | gp                   |
-| real                   | '-100.0', '1e-4'                               | nich                 |
-| sparse\_real           | '0', '0', '0', '0', '123456.78', '0', '0', '0' | bb + nich            |
-| date                   | '2014-03-31', '10pm, August 1, 1979'           | many nich + many dpd |
-| text                   | 'This is a text feature.', 'Hello World!'      | many bb              |
-| tags                   | '', 'big_data machine_learning platform'       | many bb              |
-| optional\_(TYPE)       | '', ...examples of TYPE...                     | bb + TYPE            |
+| Fluent Type            | Example Values                                 | Transforms To
+|------------------------|------------------------------------------------|---------------------
+| boolean                | '0', '1', 'true', 'false'                      | bb
+| categorical            | 'Monday', 'June'                               | dd
+| unbounded\_categorical | 'CRM', '90210'                                 | dpd
+| count                  | '0', '1', '2', '3', '4'                        | gp
+| real                   | '-100.0', '1e-4'                               | nich
+| sparse\_real           | '0', '0', '0', '0', '123456.78', '0', '0', '0' | bb + nich
+| date                   | '2014-03-31', '10pm, August 1, 1979'           | many nich + many dpd
+| text                   | 'This is a text feature.', 'Hello World!'      | many bb
+| tags                   | '', 'big_data machine_learning platform'       | many bb
+| optional\_(TYPE)       | '', ...examples of TYPE...                     | bb + TYPE
 
 Text fields typically transform to 100-1000 boolean features
 corresponding to word presence of words that occur in at least 1% of documents.
@@ -151,14 +151,14 @@ and assignments can be streamed out via stdout.
 
 ## Querying Results <a name="query"/>
 
-Loom supports flexible, interactive querying of inference results. These queries are divided between 
+Loom supports flexible, interactive querying of inference results. These queries are divided between
 low-level operations, implemented in [loom.runner.query](/loom/runner.py), and higher-level operations, in [loom.preql](/loom/preql.py).
 
-The **low-level primitives**, `sample` and `score`, are written in C++. They can be accessed as a 
-transformation of protobuf messages via the `loom.runner.query` function. See `src/schema.proto` 
-for the query message format.
+The **low-level primitives**, `sample`, `score`, `entropy`, and `score_derivative` are written in C++.
+They can be accessed as a transformation of protobuf messages via the `loom.runner.query` function.
+See `src/schema.proto` for the query message format.
 
-The `loom.query` module provides a convenient way to create a persistent query server with both protobuf and python interfaces. 
+The `loom.query` module provides a convenient way to create a persistent query server with both protobuf and python interfaces.
 
 <!--
 * `sample` FIXME explain
@@ -166,8 +166,8 @@ The `loom.query` module provides a convenient way to create a persistent query s
 * `score` FIXME explain
 -->
 
-**Higher level operations** are supported via the `loom.preql` module. Assuming that you have completed an 
-inference run named `iris`, you can create a query server using the following convenience method in `loom.tasks`:
+**Higher level operations** are supported via the `loom.preql` module.
+Assuming that you have completed an inference run named `iris`, you can create a query server using the following convenience method in `loom.tasks`:
 
     import loom.tasks
     server = loom.tasks.query('iris')
@@ -176,23 +176,23 @@ inference run named `iris`, you can create a query server using the following co
 
     print server.relate(['class'])
 
-* `predict` is a very flexible operation that returns a simulated values for one or more unknown columns, 
-given fixed values for a different subset of columns. This flexibility is possible because loom learns a 
-joint model of the data. Standard classification and regression tasks are therefore one special case, in which 
+* `predict` is a very flexible operation that returns a simulated values for one or more unknown columns,
+given fixed values for a different subset of columns. This flexibility is possible because loom learns a
+joint model of the data. Standard classification and regression tasks are therefore one special case, in which
 the value of one "dependent" or "target" column is predicted given values for all of the other columns (known as "independent variables", "predictors", "regressors", or "features").
 
   Some examples of `predict` usage are as follows:
 
   * Fix all but one column and predict that column.
-  
+
     <!-- FIXME explanation and example usage -->
-    
+
   * Fix some columns, predict some other columns.
-  
+
     <!-- FIXME explanation and example usage -->
-    
+
   * Fix no columns, predict all columns.
-  
+
     <!-- FIXME explanation and example usage -->
 
 <!--

--- a/loom/preql.py
+++ b/loom/preql.py
@@ -210,7 +210,7 @@ class PreQL(object):
             raise ValueError('invalid row (bad length): {}'.format(row))
         encoded_row = []
         for pos, value in enumerate(row):
-            if value is not None:  # FIXME is this correct?
+            if value:
                 assert isinstance(value, str), value
                 encode = self._name_to_encode[self._feature_names[pos]]
                 try:

--- a/loom/test/test_preql.py
+++ b/loom/test/test_preql.py
@@ -105,6 +105,8 @@ def test_predict(root, rows_csv, encoding, **unused):
             rows_in = os.listdir(rows_csv)[0]
             rows_in = os.path.join(rows_csv, rows_in)
             preql.predict(rows_in, COUNT, result_out, id_offset=True)
+            print 'DEBUG', open_compressed(rows_in).read()
+            print 'DEBUG', open_compressed(result_out).read()
             _check_predictions(rows_in, result_out, encoding)
 
 

--- a/loom/test/test_transforms.py
+++ b/loom/test/test_transforms.py
@@ -66,7 +66,7 @@ def generate_example(schema_csv, rows_csv, row_count=100):
 
 
 def test_transforms():
-    name = 'test_transforms'
+    name = 'test_transforms.test_transforms'
     with tempdir() as temp:
         schema_csv = os.path.join(temp, 'schema.csv')
         rows_csv = os.path.join(temp, 'rows.csv.gz')

--- a/loom/transforms.py
+++ b/loom/transforms.py
@@ -174,13 +174,13 @@ class PresenceTransform(object):
 
     def forward(self, row_dict):
         present = (self.feature_name in row_dict)
-        row_dict[self.present_name] = encode_bool(present)
+        row_dict[self.present_name] = decode_bool(present)
         if present:
             row_dict[self.value_name] = row_dict[self.feature_name]
 
     def backward(self, row_dict):
         if self.present_name in row_dict:
-            if decode_bool(row_dict[self.present_name]):
+            if encode_bool(row_dict[self.present_name]):
                 row_dict[self.feature_name] = row_dict[self.value_name]
             else:
                 del row_dict[self.feature_name]  # nonmonotone
@@ -206,13 +206,13 @@ class SparseRealTransform(object):
         if feature_name in row_dict:
             value = float(row_dict[feature_name])
             nonzero = (value == self.tare_value)
-            row_dict[self.nonzero_name] = encode_bool(nonzero)
+            row_dict[self.nonzero_name] = decode_bool(nonzero)
             if nonzero:
                 row_dict[self.value_name] = value
 
     def backward(self, row_dict):
         if self.nonzero_name in row_dict:
-            if decode_bool(row_dict[self.nonzero_name]):
+            if encode_bool(row_dict[self.nonzero_name]):
                 if self.value_name in row_dict:
                     row_dict[self.feature_name] = row_dict[self.value_name]
             else:


### PR DESCRIPTION
This PR's goal is to allow preql methods to use both basic and fluent features (post and pre transform, resp). The biggest change is that `conditioning_row` can now be either a list (WRT the schema `preql.feature_names`) or a dict; if it is a dict, the keys can be either fluent or basic features.
